### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The [Model Context Protocol](https://www.anthropic.com/news/model-context-protocol) (MCP) is an open standard that enables seamless integration between Large Language Models (LLMs) and external tools. Whilst it can be implemented in any AI system, including custom LLM setups, the degree of integration and optimisation varies based on the model's architecture and capabilities.
 
+<a href="https://glama.ai/mcp/servers/@saidsef/mcp-github-pr-issue-analyser">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@saidsef/mcp-github-pr-issue-analyser/badge" alt="GitHub PR Issue Analyser MCP server" />
+</a>
+
 This MCP application serves as a bridge between LLMs and GitHub's repository management features, offering automated analysis of pull requests and comprehensive issue management. It provides a robust set of tools to fetch PR details, create issues, and update issues directly from your desktop LLM. The application is designed with modularity in mind, supporting extensibility via the MCP tool interface and seamless integration with existing workflows.
 
 The toolset enables automated PR analysis, issue tracking, tagging and release management through a standardised MCP interface, making it ideal for teams seeking to streamline their GitHub workflow automation.


### PR DESCRIPTION
This PR adds a badge for the [GitHub PR Issue Analyser](https://glama.ai/mcp/servers/@saidsef/mcp-github-pr-issue-analyser) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@saidsef/mcp-github-pr-issue-analyser">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@saidsef/mcp-github-pr-issue-analyser/badge" alt="GitHub PR Issue Analyser MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.