### PR TITLE
chore: clean up response messages and bump version to 2.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-github-pr-issue-analyser"
-version = "2.4.0"
+version = "2.4.1"
 description = "MCP GitHub Issues Create/Update and PR Analyse"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -230,7 +230,7 @@ class PRIssueAnalyser:
             logging.info(f"Listing open {issue} for {repo_owner}")
             try:
                 open_issues_prs = self.gi.list_open_issues_prs(repo_owner, issue)
-                return f"Successfully listed open {issue} for {repo_owner}: {open_issues_prs}"
+                return f"{open_issues_prs}"
             except Exception as e:
                 error_msg = f"Error listing {issue} for {repo_owner}: {str(e)}"
                 logging.error(error_msg)

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ cli = [
 
 [[package]]
 name = "mcp-github-pr-issue-analyser"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
Resolves:  #69 

## Changes

**Version Update:**
- Bumped version from 2.4.0 to 2.4.1 in `pyproject.toml` and `uv.lock`

**Code Improvement:**
- Simplified response message in `list_github_issues_prs()` function
- Removed redundant success message prefix, returning clean output directly
- Changed from: `"Successfully listed open {issue} for {repo_owner}: {open_issues_prs}"`
- Changed to: `"{open_issues_prs}"`

This change improves the user experience by providing cleaner, more direct output from the GitHub issues/PR listing functionality.