### PR TITLE
fix: ipv6 response

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-github-pr-issue-analyser"
-version = "2.6.1"
+version = "2.6.2"
 description = "MCP GitHub Issues Create/Update and PR Analyse"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -290,8 +290,8 @@ class GitHubIntegration:
             response.raise_for_status()
             pr_data = response.json()
             open_prs = {
-                "total_open_prs": pr_data['total_count'],
-                "pull_requests": [
+                "total": pr_data['total_count'],
+                f"open_{issue}s": [
                     {
                         "url": item['html_url'],
                         "title": item['title'],
@@ -307,11 +307,11 @@ class GitHubIntegration:
                 ]
             }
 
-            logging.info(f"Open PRs listed successfully")
+            logging.info(f"Open {issue}s listed successfully")
             return open_prs
 
         except Exception as e:
-            logging.error(f"Error listing open PRs: {str(e)}")
+            logging.error(f"Error listing open {issue}s: {str(e)}")
             traceback.print_exc()
             return None
 

--- a/src/mcp_github/ip_integration.py
+++ b/src/mcp_github/ip_integration.py
@@ -63,7 +63,8 @@ class IPIntegration:
         return response.json()
     except requests.RequestException as e:
         logging.error(f"Error fetching IP info: {e}")
-        logging.debug(traceback.format_exc())
+        logging.debug(e)
+        traceback.print_exc()
         return {}
 
   def get_ipv4_info(self) -> Dict[str, Any]:
@@ -79,7 +80,8 @@ class IPIntegration:
           return ipv4
       except requests.RequestException as e:
           logging.error(f"Error fetching IPv4 info: {e}")
-          logging.debug(traceback.format_exc())
+          logging.debug(e)
+          traceback.print_exc()
           return {}
 
   def get_ipv6_info(self) -> Dict[str, Any]:
@@ -94,17 +96,15 @@ class IPIntegration:
         Logs an error message and returns an empty dictionary if a `requests.RequestException` is raised during the fetch operation.
         Also logs the full traceback at the debug level for troubleshooting.
     """
-    # Override the allowed_gai_family method to use IPv6
-    def allowed_gai_family():
-        return socket.AF_INET6
-    urllib3_connection.allowed_gai_family = allowed_gai_family
     try:
+        urllib3_connection.allowed_gai_family = lambda: socket.AF_INET6
         ipv6 = self.get_info(self.ipv6_api_url)
         if not ipv6:
             logging.error("No IPv6 information found.")
-            return {}
+            return {"error": "No IPv6 information found."}
         return ipv6
     except requests.RequestException as e:
         logging.error(f"Error fetching IPv6 info: {e}")
-        logging.debug(traceback.format_exc())
-        return {}
+        logging.debug(e)
+        traceback.print_exc()
+        return {"error": f"Failed to fetch IPv6 information: {str(e)}"}

--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -358,15 +358,19 @@ class PRIssueAnalyser:
             logging.info({"status": "info", "message": "Fetching IPv4 and IPv6 information"})
             try:
                 ipv4_info = self.ip.get_ipv4_info()
-                ipv6_info = self.ip.get_ipv6_info()
-                if ipv4_info is None:
+                try:
+                    ipv6_info = self.ip.get_ipv6_info()
+                except Exception as e:
+                    logging.error(f"Error fetching IPv6 info: {e}")
+                    ipv6_info = None
+                if not isinstance(ipv4_info, dict) or ipv4_info is None:
                     logging.info({"status": "error", "message": "No changes returned from getv4_ip_info"})
-                    return {}
-                if ipv6_info is None:
+                    return {"status": "No IPv4 information available"}
+                if not isinstance(ipv6_info, dict) or ipv6_info is None or "ip" not in ipv6_info:
                     logging.info({"status": "error", "message": "No changes returned from getv6_ip_info"})
-                    return {}
-                if ipv4_info and ipv6_info:
-                    ipv4_info["ipv6"] = ipv6_info["ip"]
+                    return {"status": "No IPv6 information available"}
+                else:
+                    ipv4_info["ipv6"] = ipv6_info.get("ip", "No IPv6 address found")
                 logging.info({"status": "success", "message": "Successfully fetched IPv4 and IPv6 information"})
                 return ipv4_info
             except Exception as e:


### PR DESCRIPTION
This pull request introduces improvements to error handling and logging in both the GitHub and IP integration modules. The changes standardize log messages, enhance the clarity of error reporting, and ensure more informative return values when failures occur.

**Logging and error handling improvements:**

* Updated logging messages in `list_open_issues_prs` to dynamically reflect whether PRs or issues are being listed, and standardized error messages for better clarity.
* Changed the structure of returned data in `list_open_issues_prs` to use `"total"` and `"open_{issue}s"` keys for consistency, replacing `"total_open_prs"` and `"pull_requests"`.

**IP integration enhancements:**

* Replaced `traceback.format_exc()` with direct logging of exception objects and added `traceback.print_exc()` for more detailed error diagnostics in `get_info`, `get_ipv4_info`, and `get_ipv6_info`. [[1]](diffhunk://#diff-6e5cb9fb20d2907a2adc2ffbb2ec40a08b580731fc48a5b44a5e888090a46309L66-R67) [[2]](diffhunk://#diff-6e5cb9fb20d2907a2adc2ffbb2ec40a08b580731fc48a5b44a5e888090a46309L82-R84) [[3]](diffhunk://#diff-6e5cb9fb20d2907a2adc2ffbb2ec40a08b580731fc48a5b44a5e888090a46309L98-R111)
* Modified `get_ipv6_info` to return a structured error dictionary instead of an empty one when IPv6 information is unavailable or a request fails, improving downstream error handling.
* Added a nested try/except block for IPv6 info retrieval in `get_ipv4_ipv6_info` to catch and log exceptions specifically for IPv6, preventing failures from impacting the rest of the process.