### PR TITLE
feat: dynamic host and port for mcp http

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ LABEL org.opencontainers.image.documentation="https://github.com/saidsef/mcp-git
 LABEL org.opencontainers.image.source="https://github.com/saidsef/mcp-github-pr-issue-analyser.git"
 LABEL org.opencontainers.image.licenses="Apache License, Version 2.0"
 
+ARG PORT=8081
+
 ENV MCP_ENABLE_REMOTE="true"
+ENV PORT=${PORT}
 
 WORKDIR /app
 COPY pyproject.toml requirements.txt /app/
@@ -16,6 +19,6 @@ RUN pip install -r requirements.txt
 
 RUN uv sync
 
-EXPOSE 8000
+EXPOSE ${PORT}/tcp
 
 CMD ["uv", "run", "mcp-github-pr-issue-analyser"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-github-pr-issue-analyser"
-version = "3.2.1"
+version = "3.2.2"
 description = "MCP GitHub Issues Create/Update and PR Analyse"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -31,6 +31,9 @@ from .ip_integration import IPIntegration as IP
 logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARNING)
 
+PORT = int(getenv("PORT", 8081))
+HOST = getenv("HOST", "localhost")
+
 class PRIssueAnalyser:
     """
     PRIssueAnalyser is a class that provides an interface for analyzing GitHub Pull Requests (PRs) and managing GitHub Issues, Tags, and Releases, as well as retrieving IP information. It integrates with GitHub and an MCP (Multi-Component Platform) server to expose a set of tools for PR and issue management, and can be run as an MCP server using either SSE or stdio transport.
@@ -92,6 +95,8 @@ class PRIssueAnalyser:
           - Use get_ipv4_info and get_ipv6_info for IP information
           - Always maintain a professional, clear and concise tone
             """,
+            host=HOST,
+            port=PORT,
         )
         logging.info("MCP Server initialized")
 
@@ -109,19 +114,13 @@ class PRIssueAnalyser:
     def run(self):
         """
         Runs the MCP server for GitHub PR analysis.
-        This method checks the 'MCP_ENABLE_REMOTE' environment variable to determine the transport mechanism for
-        the MCP server. If 'MCP_ENABLE_REMOTE' is set, it uses Server-Sent Events (SSE) transport; otherwise, it defaults to standard input/output (stdio) transport
-        Returns:
-            None
-        Error Handling:
-            Logs any exceptions that occur during server execution and prints the traceback
-            to standard error for debugging purposes.
+        Uses HTTP transport if MCP_ENABLE_REMOTE is set, otherwise uses stdio.
         """
-        MCP_ENABLE_REMOTE = getenv("MCP_ENABLE_REMOTE", None)
+        MCP_ENABLE_REMOTE = getenv("MCP_ENABLE_REMOTE", False)
         try:
             logging.info("Running MCP Server for GitHub PR Analysis.")
             if MCP_ENABLE_REMOTE:
-                self.mcp.run(transport='sse')
+                self.mcp.run(transport='streamable-http')
             else:
                 self.mcp.run(transport='stdio')
         except Exception as e:


### PR DESCRIPTION
This pull request updates the MCP GitHub PR Issue Analyser to support configurable server ports, improves environment variable handling, and clarifies the remote transport mechanism. The main changes are grouped below:

**Docker and Deployment Configuration:**

* Added a `PORT` build argument and environment variable to the `Dockerfile`, making the server port configurable at build and runtime.
* Changed the Docker `EXPOSE` instruction to use the dynamic `PORT` value, allowing for flexible port mapping.

**Application Initialization and Runtime:**

* Updated `src/mcp_github/issues_pr_analyser.py` to read the `PORT` and `HOST` from environment variables, defaulting to `8081` and `localhost`, and passed these to the MCP server initialization. [[1]](diffhunk://#diff-19aeb4d921f54f2842ec2fe9d4e57761c03b9afdbc40712a9099ad3756cdcf6aR34-R36) [[2]](diffhunk://#diff-19aeb4d921f54f2842ec2fe9d4e57761c03b9afdbc40712a9099ad3756cdcf6aR98-R99)
* Changed the remote transport in the `run` method from Server-Sent Events (`sse`) to streamable HTTP (`streamable-http`), and improved the environment variable logic for enabling remote mode.

**Versioning:**

* Bumped the project version in `pyproject.toml` from `3.2.0` to `3.2.2` to reflect these updates.