### PR TITLE
chore(graphql): increase timeout to x4

### DIFF
--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -907,7 +907,7 @@ class GitHubIntegration:
                 'https://api.github.com/graphql',
                 json={'query': query, 'variables': variables},
                 headers=self._get_headers(),
-                timeout=TIMEOUT * 2  # Double timeout for GraphQL queries (can be complex)
+                timeout=TIMEOUT * 4  # Double timeout for GraphQL queries (can be complex)
             )
             response.raise_for_status()
             query_data = response.json()


### PR DESCRIPTION
This pull request makes a minor adjustment to the timeout setting for GraphQL queries in the `user_activity_query` method. The timeout has been increased to allow more time for potentially complex queries to complete. 

* Increased the timeout for GraphQL queries in the `user_activity_query` method in `src/mcp_github/github_integration.py` from double to quadruple the base `TIMEOUT` value, improving reliability for complex queries.