### PR TITLE
fix(github): replace conint with int for per_page parameter in GitHubIntegration methods

### DIFF
--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -35,7 +35,6 @@ logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARNING)
 
 class GitHubIntegration:
-    PerPage = conint(ge=1, le=100)
 
     def __init__(self):
         """
@@ -317,7 +316,7 @@ class GitHubIntegration:
             repo_owner: str,
             issue: Literal['pr', 'issue'] = 'pr',
             filtering: Literal['user', 'owner', 'involves'] = 'involves',
-            per_page: Annotated[PerPage, "Number of results per page (1-100)"] = 50,
+            per_page: Annotated[int, "Number of results per page (1-100)"] = 50,
             page: int = 1
     ) -> Dict[str, Any]:
         """
@@ -326,7 +325,7 @@ class GitHubIntegration:
             repo_owner (str): The owner of the repository.
             issue (Literal['pr', 'issue']): The type of items to list, either 'pr' for pull requests or 'issue' for issues. Defaults to 'pr'.
             filtering (Literal['user', 'owner', 'involves']): The filtering criteria for the search. Defaults to 'involves'.
-            per_page (Annotated[int, PerPage]): The number of results to return per page, range 1-100. Defaults to 50.
+            per_page (Annotated[int, "Number of results per page (1-100)"]): The number of results to return per page, range 1-100. Defaults to 50.
             page (int): The page number to retrieve. Defaults to 1.
         Returns:
             Dict[str, Any]: A dictionary containing the list of open pull requests or issues, depending on the value of the `issue` parameter.


### PR DESCRIPTION
This pull request simplifies the type annotation for the `per_page` parameter in the `list_open_issues_prs` method of `GitHubIntegration` by removing the custom `PerPage` type constraint and using a direct `int` annotation with a descriptive string instead.

Parameter annotation simplification:

* Removed the `PerPage` type alias (which used `conint` to constrain values) from the `GitHubIntegration` class.
* Updated the `per_page` parameter in the `list_open_issues_prs` method to use a plain `int` with a descriptive annotation, both in the function signature and the docstring. [[1]](diffhunk://#diff-8b0f96502f66645464bfe1259c15838b1f7d655e3515d24dbfb2ca2c0c25b845L320-R319) [[2]](diffhunk://#diff-8b0f96502f66645464bfe1259c15838b1f7d655e3515d24dbfb2ca2c0c25b845L329-R328)