### PR TITLE
feat(cache): add ResponseCachingMiddleware for tools and skills

### DIFF
--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -27,6 +27,7 @@ from os import getenv
 from pathlib import Path
 from typing import Any
 from fastmcp import FastMCP
+from fastmcp.apps.choice import Choice
 from fastmcp.apps.generative import GenerativeUI
 from fastmcp.server.middleware.caching import (
     CallToolSettings,
@@ -122,7 +123,8 @@ class PRIssueAnalyser:
           - skill://ip-lookup/SKILL.md — retrieve IPv4/IPv6 network information
             """,
         )
-        self.mcp.add_provider(GenerativeUI())
+        self.mcp.add_provider(Choice(name="github_pr_issue_analyser"))
+        self.mcp.add_provider(GenerativeUI(tool_name="github_pr_issue_analyser_ui"))
         self.mcp.add_middleware(
             ResponseCachingMiddleware(
                 list_tools_settings=ListToolsSettings(ttl=None),

--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -24,10 +24,18 @@ import logging
 import inspect
 import traceback
 from os import getenv
+from pathlib import Path
 from typing import Any
 from fastmcp import FastMCP
-from fastmcp.apps.choice import Choice
 from fastmcp.apps.generative import GenerativeUI
+from fastmcp.server.middleware.caching import (
+    CallToolSettings,
+    ListResourcesSettings,
+    ListToolsSettings,
+    ReadResourceSettings,
+    ResponseCachingMiddleware,
+)
+from fastmcp.server.providers.skills import SkillsDirectoryProvider
 from .github_integration import GitHubIntegration as GI
 from .ip_integration import IPIntegration as IP
 
@@ -102,10 +110,27 @@ class PRIssueAnalyser:
           - Use create_tag and create_release for release management
           - Use get_ipv4_info and get_ipv6_info for IP information
           - Always maintain a professional, clear and concise tone
+
+          ## Skills
+          Workflow guidance is available as MCP resources under the skill:// URI scheme:
+          - skill://pr-analysis/SKILL.md — fetch and analyse PR diffs and metadata
+          - skill://pr-review/SKILL.md — post inline comments and submit review decisions
+          - skill://pr-management/SKILL.md — create, update, assign, and merge PRs
+          - skill://issue-management/SKILL.md — create, update, and list issues
+          - skill://release-management/SKILL.md — tag commits and publish releases
+          - skill://user-activity/SKILL.md — look up user profiles and contribution history
+          - skill://ip-lookup/SKILL.md — retrieve IPv4/IPv6 network information
             """,
         )
-        self.mcp.add_provider(Choice())
         self.mcp.add_provider(GenerativeUI())
+        self.mcp.add_middleware(
+            ResponseCachingMiddleware(
+                list_tools_settings=ListToolsSettings(ttl=None),
+                list_resources_settings=ListResourcesSettings(ttl=None),
+                read_resource_settings=ReadResourceSettings(ttl=None),
+                call_tool_settings=CallToolSettings(enabled=False),
+            )
+        )
         logging.info("MCP Server initialised")
 
         self._register_tools()
@@ -120,6 +145,9 @@ class PRIssueAnalyser:
                 inspect.isfunction(method) or inspect.ismethod(method)
             ) and not name.startswith("_"):
                 self.mcp.add_tool(method)
+
+        skills_path = Path(__file__).parent / "skills"
+        self.mcp.add_provider(SkillsDirectoryProvider(skills_path))
 
     def run(self):
         """

--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -138,6 +138,7 @@ class PRIssueAnalyser:
     def _register_tools(self):
         self.register_tools(self.gi)
         self.register_tools(self.ip)
+        self.mcp.add_provider(SkillsDirectoryProvider(Path(__file__).parent / "skills"))
 
     def register_tools(self, methods: Any = None) -> None:
         for name, method in inspect.getmembers(methods):
@@ -145,9 +146,6 @@ class PRIssueAnalyser:
                 inspect.isfunction(method) or inspect.ismethod(method)
             ) and not name.startswith("_"):
                 self.mcp.add_tool(method)
-
-        skills_path = Path(__file__).parent / "skills"
-        self.mcp.add_provider(SkillsDirectoryProvider(skills_path))
 
     def run(self):
         """


### PR DESCRIPTION
## Summary

- Adds FastMCP's built-in `ResponseCachingMiddleware` to cache `tools/list`, `resources/list`, and `resources/read` (skill SKILL.md files) with no expiry (`ttl=None`) — items are cached for the container's lifetime, which is reset on every redeploy
- Tool call caching is **disabled** (`enabled=False`): GitHub PR/issue/release data changes frequently and stale results would be incorrect
- Uses the default in-memory `MemoryStore` backend — no new dependencies, no external services required
- Registers `SkillsDirectoryProvider` once in `_register_tools()` instead of inside `register_tools()` (which is called per-integration), preventing duplicate provider registration
- Adds explicit `name`/`tool_name` to `Choice` and `GenerativeUI` providers to avoid conflicts
- Adds skills workflow guidance to the server instructions under the `skill://` URI scheme

## Test plan

- [x] Start server in HTTP mode (`MCP_ENABLE_REMOTE=true`) and call `tools/list` twice — second response served from cache
- [x] Read a skill resource (e.g. `skill://pr-analysis/SKILL.md`) twice — second read served from cache
- [x] Call a GitHub tool (e.g. `get_pr_content`) with same args — confirm live data is returned (cache bypassed)
- [x] Build and run with read-only filesystem:
  ```sh
  docker build -t mcp-test --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 .
  docker run --read-only --tmpfs /tmp -e GITHUB_TOKEN="<token>" -p 8081:8081 mcp-test
  ```