### PR TITLE
feat(skills): add SKILL.md definitions for all skill directories

### DIFF
--- a/src/mcp_github/skills/ip-lookup/SKILL.md
+++ b/src/mcp_github/skills/ip-lookup/SKILL.md
@@ -21,9 +21,11 @@ Fetch network and geolocation metadata for the MCP server's public IP addresses.
 Both tools take no parameters.
 
 ### `get_ipv4_info`
+
 Returns: JSON object from `https://ipinfo.io/json`
 
 ### `get_ipv6_info`
+
 Returns: JSON object from `https://v6.ipinfo.io/json`
 
 > **Note**: `get_ipv6_info` temporarily monkey-patches the socket family to `AF_INET6` to force an IPv6 connection. This is reverted automatically after the call. Do not call this concurrently with other network operations.

--- a/src/mcp_github/skills/ip-lookup/SKILL.md
+++ b/src/mcp_github/skills/ip-lookup/SKILL.md
@@ -1,0 +1,50 @@
+---
+description: Retrieve geolocation and network information for the server's current IPv4 and IPv6 addresses via ipinfo.io
+---
+
+# IP Lookup
+
+Fetch network and geolocation metadata for the MCP server's public IP addresses.
+
+## Prerequisites
+
+- No parameters required — lookups are for the server's own outbound IP
+- Outbound internet access to `ipinfo.io` must be available
+
+## Workflow
+
+1. **IPv4 lookup** — call `get_ipv4_info` to get the server's public IPv4 address and associated metadata
+2. **IPv6 lookup** — call `get_ipv6_info` to get the server's public IPv6 address (if available)
+
+## Tool Parameters
+
+Both tools take no parameters.
+
+### `get_ipv4_info`
+Returns: JSON object from `https://ipinfo.io/json`
+
+### `get_ipv6_info`
+Returns: JSON object from `https://v6.ipinfo.io/json`
+
+> **Note**: `get_ipv6_info` temporarily monkey-patches the socket family to `AF_INET6` to force an IPv6 connection. This is reverted automatically after the call. Do not call this concurrently with other network operations.
+
+## Response Fields
+
+| Field | Description | Example |
+|---|---|---|
+| `ip` | Public IP address | `"203.0.113.1"` |
+| `hostname` | Reverse DNS hostname | `"host.example.com"` |
+| `city` | City of the IP | `"London"` |
+| `region` | Region/state | `"England"` |
+| `country` | ISO 3166-1 alpha-2 country code | `"GB"` |
+| `loc` | Latitude,Longitude | `"51.5074,-0.1278"` |
+| `org` | ASN and organisation name | `"AS12345 Example ISP"` |
+| `postal` | Postal/ZIP code | `"EC1A"` |
+| `timezone` | IANA timezone | `"Europe/London"` |
+
+## Best Practices
+
+- Use `get_ipv4_info` for standard connectivity diagnostics — it is always available
+- Use `get_ipv6_info` only when IPv6 connectivity is specifically needed; it may fail if the network does not support IPv6
+- If `get_ipv6_info` fails with a connection error, the server's network does not have IPv6 egress — this is expected in many environments
+- Do not use these tools to geolocate arbitrary external IPs — they only report the server's own addresses

--- a/src/mcp_github/skills/issue-management/SKILL.md
+++ b/src/mcp_github/skills/issue-management/SKILL.md
@@ -1,0 +1,75 @@
+---
+description: Create, update, and list GitHub issues with proper labels, state management, and duplicate checking
+---
+
+# Issue Management
+
+Create new issues, update existing ones, and list open issues or PRs with filtering.
+
+## Prerequisites
+
+- `repo_owner` and `repo_name` for the target repository
+- GitHub token with `repo` write access
+
+## Workflow
+
+### Creating an Issue
+1. Call `list_open_issues_prs` to check for existing duplicates before creating
+2. Call `create_issue` with title, body, and any additional labels
+   - Note: the `mcp` label is automatically added to every created issue
+
+### Updating an Issue
+1. Call `update_issue` to change the title, body, state, or labels
+2. Use `state="closed"` to close a resolved issue
+
+### Listing Issues/PRs
+1. Call `list_open_issues_prs` with filtering options to search for relevant items
+
+## Tool Parameters
+
+### `create_issue`
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `repo_owner` | str | — | GitHub organisation or username |
+| `repo_name` | str | — | Repository name |
+| `title` | str | — | Issue title |
+| `body` | str | — | Issue description (Markdown) |
+| `labels` | list[str] | `[]` | Additional labels (the `mcp` label is always added) |
+
+### `update_issue`
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `repo_owner` | str | — | GitHub organisation or username |
+| `repo_name` | str | — | Repository name |
+| `issue_number` | int | — | Issue number |
+| `title` | str | — | Updated title |
+| `body` | str | — | Updated body (Markdown) |
+| `labels` | list[str] | `[]` | Replacement label set |
+| `state` | str | `open` | `open` or `closed` |
+
+### `list_open_issues_prs`
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `repo_owner` | str | — | GitHub organisation or username |
+| `issue` | str | `pr` | `pr` for pull requests, `issue` for issues |
+| `filtering` | str | `involves` | GitHub filter: `involves`, `assigned`, `created`, `mentioned` |
+| `per_page` | int | `50` | Results per page (max 100) |
+| `page` | int | `1` | Page number |
+
+## Filtering Guide
+
+| Filter | Returns issues/PRs where you are... |
+|---|---|
+| `involves` | Involved in any way (author, assignee, mentioned, subscribed) |
+| `assigned` | Assigned as the responsible party |
+| `created` | The original author |
+| `mentioned` | Mentioned by @username |
+
+## Best Practices
+
+- Always search for duplicates with `list_open_issues_prs` before creating a new issue
+- Write issue bodies in Markdown; include steps to reproduce for bugs, or acceptance criteria for features
+- Use labels consistently — common labels: `bug`, `enhancement`, `documentation`, `good first issue`
+- Close issues with `state="closed"` once resolved rather than deleting them
+- Reference related PRs in issue bodies (e.g. `Resolved by #123`)
+- The `mcp` label is auto-added and identifies issues created via this tool

--- a/src/mcp_github/skills/issue-management/SKILL.md
+++ b/src/mcp_github/skills/issue-management/SKILL.md
@@ -14,20 +14,24 @@ Create new issues, update existing ones, and list open issues or PRs with filter
 ## Workflow
 
 ### Creating an Issue
+
 1. Call `list_open_issues_prs` to check for existing duplicates before creating
 2. Call `create_issue` with title, body, and any additional labels
    - Note: the `mcp` label is automatically added to every created issue
 
 ### Updating an Issue
+
 1. Call `update_issue` to change the title, body, state, or labels
 2. Use `state="closed"` to close a resolved issue
 
 ### Listing Issues/PRs
+
 1. Call `list_open_issues_prs` with filtering options to search for relevant items
 
 ## Tool Parameters
 
 ### `create_issue`
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `repo_owner` | str | — | GitHub organisation or username |
@@ -37,6 +41,7 @@ Create new issues, update existing ones, and list open issues or PRs with filter
 | `labels` | list[str] | `[]` | Additional labels (the `mcp` label is always added) |
 
 ### `update_issue`
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `repo_owner` | str | — | GitHub organisation or username |
@@ -48,6 +53,7 @@ Create new issues, update existing ones, and list open issues or PRs with filter
 | `state` | str | `open` | `open` or `closed` |
 
 ### `list_open_issues_prs`
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `repo_owner` | str | — | GitHub organisation or username |

--- a/src/mcp_github/skills/pr-analysis/SKILL.md
+++ b/src/mcp_github/skills/pr-analysis/SKILL.md
@@ -42,6 +42,7 @@ Returns: raw patch string (unified diff format). Each file section starts with `
 ## Analysis Output Structure
 
 When summarising a PR, cover:
+
 - **What**: short summary of the change
 - **Why**: inferred from description and commit context
 - **Scope**: files changed, lines added/removed

--- a/src/mcp_github/skills/pr-analysis/SKILL.md
+++ b/src/mcp_github/skills/pr-analysis/SKILL.md
@@ -20,6 +20,7 @@ Retrieve and synthesise PR metadata and code changes to understand what a pull r
 ## Tool Parameters
 
 ### `get_pr_content`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `repo_owner` | str | GitHub organisation or username |
@@ -29,6 +30,7 @@ Retrieve and synthesise PR metadata and code changes to understand what a pull r
 Returns: `PRContent` — title, body, author, state, draft status, base/head refs, labels, mergeable state.
 
 ### `get_pr_diff`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `repo_owner` | str | GitHub organisation or username |

--- a/src/mcp_github/skills/pr-analysis/SKILL.md
+++ b/src/mcp_github/skills/pr-analysis/SKILL.md
@@ -1,0 +1,54 @@
+---
+description: Analyse GitHub Pull Requests by fetching metadata and diffs to produce a comprehensive review summary
+---
+
+# PR Analysis
+
+Retrieve and synthesise PR metadata and code changes to understand what a pull request does, why, and how.
+
+## Prerequisites
+
+- `repo_owner`, `repo_name`, and `pr_number` for the target PR
+- GitHub token with `repo` read access
+
+## Workflow
+
+1. **Fetch PR metadata** — call `get_pr_content` to get title, description, author, state, base/head branches, and labels
+2. **Fetch the diff** — call `get_pr_diff` to get the raw unified diff (patch format) of all changed files
+3. **Synthesise** — combine metadata and diff to produce a structured analysis
+
+## Tool Parameters
+
+### `get_pr_content`
+| Parameter | Type | Description |
+|---|---|---|
+| `repo_owner` | str | GitHub organisation or username |
+| `repo_name` | str | Repository name |
+| `pr_number` | int | Pull request number |
+
+Returns: `PRContent` — title, body, author, state, draft status, base/head refs, labels, mergeable state.
+
+### `get_pr_diff`
+| Parameter | Type | Description |
+|---|---|---|
+| `repo_owner` | str | GitHub organisation or username |
+| `repo_name` | str | Repository name |
+| `pr_number` | int | Pull request number |
+
+Returns: raw patch string (unified diff format). Each file section starts with `diff --git a/... b/...`.
+
+## Analysis Output Structure
+
+When summarising a PR, cover:
+- **What**: short summary of the change
+- **Why**: inferred from description and commit context
+- **Scope**: files changed, lines added/removed
+- **Risk areas**: large diffs, security-sensitive files, config changes, dependency updates
+- **Missing items**: tests, docs updates, changelog entries
+
+## Best Practices
+
+- Always call `get_pr_content` before `get_pr_diff` — metadata gives context for interpreting the diff
+- For large diffs (>500 lines), focus analysis on high-risk files first (auth, config, deps)
+- A draft PR (`draft: true`) is not ready for merge review — note this in the analysis
+- If `mergeable` is `false` or `null`, flag merge conflicts before proceeding

--- a/src/mcp_github/skills/pr-management/SKILL.md
+++ b/src/mcp_github/skills/pr-management/SKILL.md
@@ -15,14 +15,17 @@ Create new pull requests, keep them up to date, and safely merge them when ready
 ## Workflow
 
 ### Opening a PR
+
 1. Call `create_pr` with title, body, head branch, and base branch
 2. Optionally mark as `draft=True` if not ready for review
 
 ### Updating a PR
+
 1. Call `update_pr_description` to revise the title or body
 2. Call `update_assignees` to assign or reassign users
 
 ### Merging a PR
+
 1. Confirm the PR is approved and all checks pass (check `mergeable` via `get_pr_content`)
 2. Call `merge_pr` with the appropriate merge method
 3. **Always confirm with the user before merging**
@@ -30,6 +33,7 @@ Create new pull requests, keep them up to date, and safely merge them when ready
 ## Tool Parameters
 
 ### `create_pr`
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `repo_owner` | str | — | GitHub organisation or username |
@@ -41,6 +45,7 @@ Create new pull requests, keep them up to date, and safely merge them when ready
 | `draft` | bool | `False` | Open as draft PR |
 
 ### `update_pr_description`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `repo_owner` | str | GitHub organisation or username |
@@ -50,6 +55,7 @@ Create new pull requests, keep them up to date, and safely merge them when ready
 | `new_description` | str | Updated PR body (Markdown) |
 
 ### `update_assignees`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `repo_owner` | str | GitHub organisation or username |
@@ -58,6 +64,7 @@ Create new pull requests, keep them up to date, and safely merge them when ready
 | `assignees` | list[str] | GitHub usernames to assign |
 
 ### `merge_pr`
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `repo_owner` | str | — | GitHub organisation or username |

--- a/src/mcp_github/skills/pr-management/SKILL.md
+++ b/src/mcp_github/skills/pr-management/SKILL.md
@@ -1,0 +1,84 @@
+---
+description: Manage the full lifecycle of a GitHub PR — create, update description, assign reviewers, and merge
+---
+
+# PR Management
+
+Create new pull requests, keep them up to date, and safely merge them when ready.
+
+## Prerequisites
+
+- `repo_owner` and `repo_name` for the target repository
+- Branches must exist before creating a PR (`head` branch must be pushed)
+- GitHub token with `repo` write access
+
+## Workflow
+
+### Opening a PR
+1. Call `create_pr` with title, body, head branch, and base branch
+2. Optionally mark as `draft=True` if not ready for review
+
+### Updating a PR
+1. Call `update_pr_description` to revise the title or body
+2. Call `update_assignees` to assign or reassign users
+
+### Merging a PR
+1. Confirm the PR is approved and all checks pass (check `mergeable` via `get_pr_content`)
+2. Call `merge_pr` with the appropriate merge method
+3. **Always confirm with the user before merging**
+
+## Tool Parameters
+
+### `create_pr`
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `repo_owner` | str | — | GitHub organisation or username |
+| `repo_name` | str | — | Repository name |
+| `title` | str | — | PR title |
+| `body` | str | — | PR description (Markdown) |
+| `head` | str | — | Source branch name |
+| `base` | str | — | Target branch name (e.g. `main`) |
+| `draft` | bool | `False` | Open as draft PR |
+
+### `update_pr_description`
+| Parameter | Type | Description |
+|---|---|---|
+| `repo_owner` | str | GitHub organisation or username |
+| `repo_name` | str | Repository name |
+| `pr_number` | int | Pull request number |
+| `new_title` | str | Updated PR title |
+| `new_description` | str | Updated PR body (Markdown) |
+
+### `update_assignees`
+| Parameter | Type | Description |
+|---|---|---|
+| `repo_owner` | str | GitHub organisation or username |
+| `repo_name` | str | Repository name |
+| `issue_number` | int | PR or issue number |
+| `assignees` | list[str] | GitHub usernames to assign |
+
+### `merge_pr`
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `repo_owner` | str | — | GitHub organisation or username |
+| `repo_name` | str | — | Repository name |
+| `pr_number` | int | — | Pull request number |
+| `commit_title` | str | optional | Custom merge commit title |
+| `commit_message` | str | optional | Custom merge commit message |
+| `merge_method` | str | `squash` | One of: `merge`, `squash`, `rebase` |
+
+## Merge Method Guide
+
+| Method | When to use |
+|---|---|
+| `squash` | Feature branches — keeps main history clean (default) |
+| `merge` | When preserving full branch commit history is important |
+| `rebase` | Linear history without a merge commit |
+
+## Best Practices
+
+- Write PR bodies in Markdown; include a summary, motivation, and testing steps
+- Always verify `mergeable` status before calling `merge_pr`
+- Use `draft=True` for work-in-progress PRs to prevent premature merges
+- Do not force-merge PRs with failing CI checks
+- After merging, delete the head branch to keep the repo clean

--- a/src/mcp_github/skills/pr-review/SKILL.md
+++ b/src/mcp_github/skills/pr-review/SKILL.md
@@ -1,0 +1,65 @@
+---
+description: Review a GitHub PR by posting inline code comments and submitting a formal review decision
+---
+
+# PR Review
+
+Post targeted inline comments on specific lines and submit a formal review (approve, request changes, or comment).
+
+## Prerequisites
+
+- Run the `pr-analysis` skill first to understand the PR before reviewing
+- `repo_owner`, `repo_name`, `pr_number` for the target PR
+- GitHub token with `repo` write access
+
+## Workflow
+
+1. **Analyse the PR** — use the `pr-analysis` skill to read diff and metadata
+2. **Post inline comments** — call `add_inline_pr_comment` for each specific line that needs feedback
+3. **Post a general comment** (optional) — call `add_pr_comments` for overall remarks not tied to a specific line
+4. **Submit the review decision** — call `update_reviews` with APPROVE, REQUEST_CHANGES, or COMMENT
+
+## Tool Parameters
+
+### `add_inline_pr_comment`
+| Parameter | Type | Description |
+|---|---|---|
+| `repo_owner` | str | GitHub organisation or username |
+| `repo_name` | str | Repository name |
+| `pr_number` | int | Pull request number |
+| `path` | str | File path relative to repo root (e.g. `src/app/main.py`) |
+| `line` | int | Line number in the **new** file (right side of diff) |
+| `comment_body` | str | Markdown comment text |
+
+### `add_pr_comments`
+| Parameter | Type | Description |
+|---|---|---|
+| `repo_owner` | str | GitHub organisation or username |
+| `repo_name` | str | Repository name |
+| `pr_number` | int | Pull request number |
+| `comment` | str | Markdown comment text for the overall PR thread |
+
+### `update_reviews`
+| Parameter | Type | Description |
+|---|---|---|
+| `repo_owner` | str | GitHub organisation or username |
+| `repo_name` | str | Repository name |
+| `pr_number` | int | Pull request number |
+| `event` | str | One of: `APPROVE`, `REQUEST_CHANGES`, `COMMENT` |
+| `body` | str (optional) | Summary body for the review |
+
+## Review Decision Guide
+
+| Decision | When to use |
+|---|---|
+| `APPROVE` | All concerns addressed, code is correct and safe to merge |
+| `REQUEST_CHANGES` | Blocking issues found (bugs, security, missing tests) |
+| `COMMENT` | Non-blocking feedback or questions, no decision yet |
+
+## Best Practices
+
+- Post all inline comments before calling `update_reviews` — they are grouped under the same review
+- Use `add_inline_pr_comment` for specific code feedback; use `add_pr_comments` for high-level remarks
+- Always include a `body` in `update_reviews` summarising the rationale for the decision
+- Do not APPROVE a draft PR (`draft: true`)
+- Reference issue numbers in comments where relevant (e.g. `Fixes #42`)

--- a/src/mcp_github/skills/pr-review/SKILL.md
+++ b/src/mcp_github/skills/pr-review/SKILL.md
@@ -22,6 +22,7 @@ Post targeted inline comments on specific lines and submit a formal review (appr
 ## Tool Parameters
 
 ### `add_inline_pr_comment`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `repo_owner` | str | GitHub organisation or username |
@@ -32,6 +33,7 @@ Post targeted inline comments on specific lines and submit a formal review (appr
 | `comment_body` | str | Markdown comment text |
 
 ### `add_pr_comments`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `repo_owner` | str | GitHub organisation or username |
@@ -40,6 +42,7 @@ Post targeted inline comments on specific lines and submit a formal review (appr
 | `comment` | str | Markdown comment text for the overall PR thread |
 
 ### `update_reviews`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `repo_owner` | str | GitHub organisation or username |

--- a/src/mcp_github/skills/release-management/SKILL.md
+++ b/src/mcp_github/skills/release-management/SKILL.md
@@ -21,6 +21,7 @@ Tag a commit and publish a GitHub release with generated or custom release notes
 ## Tool Parameters
 
 ### `get_latest_sha`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `repo_owner` | str | GitHub organisation or username |
@@ -29,6 +30,7 @@ Tag a commit and publish a GitHub release with generated or custom release notes
 Returns: SHA string of the HEAD commit on the default branch.
 
 ### `create_tag`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `repo_owner` | str | GitHub organisation or username |
@@ -37,6 +39,7 @@ Returns: SHA string of the HEAD commit on the default branch.
 | `message` | str | Annotated tag message describing the release |
 
 ### `create_release`
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `repo_owner` | str | — | GitHub organisation or username |

--- a/src/mcp_github/skills/release-management/SKILL.md
+++ b/src/mcp_github/skills/release-management/SKILL.md
@@ -1,0 +1,71 @@
+---
+description: Create annotated git tags and publish GitHub releases following semantic versioning
+---
+
+# Release Management
+
+Tag a commit and publish a GitHub release with generated or custom release notes.
+
+## Prerequisites
+
+- `repo_owner` and `repo_name` for the target repository
+- The target branch/commit must be in a releasable state (CI passing, PRs merged)
+- GitHub token with `repo` write access (requires `contents: write` permission)
+
+## Workflow
+
+1. **Get the latest SHA** — call `get_latest_sha` to retrieve the HEAD commit of the default branch
+2. **Create a tag** — call `create_tag` with a semantic version string and descriptive message
+3. **Publish the release** — call `create_release` referencing the new tag
+
+## Tool Parameters
+
+### `get_latest_sha`
+| Parameter | Type | Description |
+|---|---|---|
+| `repo_owner` | str | GitHub organisation or username |
+| `repo_name` | str | Repository name |
+
+Returns: SHA string of the HEAD commit on the default branch.
+
+### `create_tag`
+| Parameter | Type | Description |
+|---|---|---|
+| `repo_owner` | str | GitHub organisation or username |
+| `repo_name` | str | Repository name |
+| `tag_name` | str | Tag name (e.g. `v1.2.3`) |
+| `message` | str | Annotated tag message describing the release |
+
+### `create_release`
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `repo_owner` | str | — | GitHub organisation or username |
+| `repo_name` | str | — | Repository name |
+| `tag_name` | str | — | Existing tag to release from |
+| `release_name` | str | — | Human-readable release title |
+| `body` | str | — | Release notes (Markdown) |
+| `draft` | bool | `False` | Publish as draft (not publicly visible) |
+| `prerelease` | bool | `False` | Mark as pre-release (alpha/beta/rc) |
+| `generate_release_notes` | bool | `True` | Auto-generate notes from merged PRs |
+| `make_latest` | str | `"true"` | Mark as the latest release |
+
+## Semantic Versioning Guide
+
+Format: `vMAJOR.MINOR.PATCH` (e.g. `v2.1.0`)
+
+| Part | Increment when |
+|---|---|
+| MAJOR | Breaking changes to the public API |
+| MINOR | New backwards-compatible features |
+| PATCH | Backwards-compatible bug fixes |
+
+Pre-release suffixes: `v1.0.0-alpha.1`, `v1.0.0-beta.2`, `v1.0.0-rc.1`
+
+## Best Practices
+
+- Always follow semver — never re-use or delete a published tag
+- Set `draft=True` first to preview the release before publishing
+- Set `generate_release_notes=True` unless you need full manual control over the notes
+- Set `prerelease=True` for alpha/beta/rc versions
+- Tag messages should summarise the scope of the release (e.g. "Release v1.2.0: add caching layer and improve error handling")
+- Ensure all target PRs are merged before tagging

--- a/src/mcp_github/skills/user-activity/SKILL.md
+++ b/src/mcp_github/skills/user-activity/SKILL.md
@@ -19,6 +19,7 @@ Retrieve a GitHub user's profile information and their contribution history (com
 ## Tool Parameters
 
 ### `search_user`
+
 | Parameter | Type | Description |
 |---|---|---|
 | `username` | str | GitHub username to look up |
@@ -26,6 +27,7 @@ Retrieve a GitHub user's profile information and their contribution history (com
 Returns: `UserSearchResult` — login, name, bio, company, location, public repos count, followers/following, organisation memberships, pinned repositories.
 
 ### `get_user_activities`
+
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `username` | str | — | GitHub username |

--- a/src/mcp_github/skills/user-activity/SKILL.md
+++ b/src/mcp_github/skills/user-activity/SKILL.md
@@ -1,0 +1,62 @@
+---
+description: Look up a GitHub user's profile and retrieve their contribution activity with optional date and repository filtering
+---
+
+# User Activity
+
+Retrieve a GitHub user's profile information and their contribution history (commits, PRs, issues, reviews).
+
+## Prerequisites
+
+- Target GitHub `username`
+- GitHub token with `read:user` scope (GraphQL API)
+
+## Workflow
+
+1. **Look up the user profile** — call `search_user` to get bio, organisation membership, pinned repos, and follower counts
+2. **Retrieve contributions** — call `get_user_activities` to get a detailed breakdown of their activity, optionally filtered by org, repo, or date range
+
+## Tool Parameters
+
+### `search_user`
+| Parameter | Type | Description |
+|---|---|---|
+| `username` | str | GitHub username to look up |
+
+Returns: `UserSearchResult` — login, name, bio, company, location, public repos count, followers/following, organisation memberships, pinned repositories.
+
+### `get_user_activities`
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `username` | str | — | GitHub username |
+| `org` | str | `""` | Filter by organisation name (optional) |
+| `repo` | str | `""` | Filter by repository name (optional) |
+| `since` | str | `""` | Start date in ISO 8601 format: `YYYY-MM-DD` |
+| `until` | str | `""` | End date in ISO 8601 format: `YYYY-MM-DD` |
+| `max_results` | int | `50` | Maximum number of contribution entries to return |
+
+Returns: `UserActivityResult` — lists of commits, pull requests, issues, and PR reviews with counts and URLs.
+
+## Activity Types Returned
+
+| Type | Fields |
+|---|---|
+| Commits | `commitCount`, `url`, `occurredAt` |
+| Pull Requests | PR title, state, URL, creation date |
+| Issues | Issue title, state, URL, creation date |
+| PR Reviews | Review state (`APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`), PR URL |
+
+## Date Filtering
+
+- Use ISO 8601 format: `YYYY-MM-DD` (e.g. `2024-01-01`)
+- `since` is inclusive (contributions on or after this date)
+- `until` is inclusive (contributions on or before this date)
+- Omit both to retrieve the most recent contributions up to `max_results`
+
+## Best Practices
+
+- Call `search_user` first — it confirms the user exists and provides context before fetching activity
+- Use `org` and `repo` filters together to scope activity to a specific project
+- Set `max_results` conservatively (50–100) for broad date ranges to avoid large payloads
+- Use date ranges when investigating contributions during a specific sprint or quarter
+- PR review state `APPROVED` means the user approved that PR; `CHANGES_REQUESTED` means they blocked it


### PR DESCRIPTION
## Summary

- Adds `SKILL.md` files for all 7 skill directories: `ip-lookup`, `issue-management`, `pr-analysis`, `pr-management`, `pr-review`, `release-management`, `user-activity`
- Each file documents prerequisites, workflow, tool parameters, and best practices for that skill
- These files were missed from the previous PR that introduced the skills directories

## Test plan

- [x] Verify each skill directory under `src/mcp_github/skills/` contains a `SKILL.md`
- [x] Confirm skill descriptions, tool parameter tables, and best practices are accurate against the current tool implementations