### PR TITLE
feat(auth): add GitHub OAuth2 alongside static token auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG PORT=8081
 
 ENV MCP_ENABLE_REMOTE="true"
 ENV PORT=${PORT}
+ENV FASTMCP_HOME=/tmp
 
 WORKDIR /app
 COPY pyproject.toml requirements.txt /app/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,31 @@ The toolset enables automated PR analysis, issue tracking, tagging and release m
 ## Requirements
 
 - Python 3.12+
-- GitHub Personal Access Token (with `repo` scope)
+- GitHub Personal Access Token (with `repo` scope) **or** a GitHub OAuth App (client ID, secret, and a public base URL)
+
+## Authentication
+
+Two auth modes are supported. The active mode is selected automatically from environment variables.
+
+| Mode | When active | Token used for API calls |
+|------|-------------|--------------------------|
+| **Static token** (default) | `GITHUB_TOKEN` set; no `GITHUB_OAUTH_*` vars | Server's `GITHUB_TOKEN` for all calls |
+| **GitHub OAuth2** | `GITHUB_TOKEN` + all three `GITHUB_OAUTH_*` vars set | Each user's own `gho_*` token |
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_TOKEN` | Yes | GitHub PAT with `repo` scope; used as the Bearer token in static-token HTTP mode |
+| `MCP_ENABLE_REMOTE` | No | Any non-empty value enables HTTP mode (required for OAuth2) |
+| `GITHUB_OAUTH_CLIENT_ID` | OAuth2 only | GitHub OAuth App client ID |
+| `GITHUB_OAUTH_CLIENT_SECRET` | OAuth2 only | GitHub OAuth App client secret |
+| `GITHUB_OAUTH_BASE_URL` | OAuth2 only | Public base URL of the MCP server (used for the OAuth2 redirect) |
+| `PORT` | No (default `8081`) | HTTP server port |
+| `HOST` | No (default `localhost`) | HTTP server host |
+| `GITHUB_API_TIMEOUT` | No (default `5`) | Timeout in seconds for GitHub API requests |
+
+> To create a GitHub OAuth App, go to **Settings → Developer settings → OAuth Apps → New OAuth App** and set the Authorization callback URL to `<GITHUB_OAUTH_BASE_URL>/auth/callback` (e.g. `https://mcp.example.com/auth/callback`).
 
 ## Architecture Diagram
 
@@ -108,6 +132,17 @@ uvx ./
 ```
 > You can access it via `http` i.e. `http(s)://localhost:8081/mcp`
 > In HTTP mode, clients must authenticate with `Authorization: Bearer <GITHUB_TOKEN>`.
+
+Alternatively, launch MCP in `http` mode with GitHub OAuth2 authentication.
+```sh
+export GITHUB_TOKEN="<github-token>"
+export MCP_ENABLE_REMOTE=true
+export GITHUB_OAUTH_CLIENT_ID="<oauth-app-client-id>"
+export GITHUB_OAUTH_CLIENT_SECRET="<oauth-app-client-secret>"
+export GITHUB_OAUTH_BASE_URL="https://<your-public-host>"
+uvx ./
+```
+> In OAuth2 mode, users authenticate via GitHub's OAuth flow. Each user's own GitHub token is used for API calls.
 
 Alternatively, run via Docker using the published image.
 ```sh

--- a/deployment/base/deployment.yml
+++ b/deployment/base/deployment.yml
@@ -30,6 +30,8 @@ spec:
         image: ghcr.io/saidsef/mcp-github-pr-issue-analyser:latest
         imagePullPolicy: Always
         env:
+        - name: FASTMCP_HOME
+          value: /tmp
         - name : HOST
           valueFrom:
             fieldRef:

--- a/src/mcp_github/auth.py
+++ b/src/mcp_github/auth.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# /*
+#  * Copyright Said Sef
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *      https://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  */
+
+"""Authentication providers and token resolution for the MCP GitHub server."""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import time
+from os import getenv
+from typing import Optional
+
+from fastmcp.server.auth import TokenVerifier, AccessToken
+from mcp.shared.auth import OAuthClientInformationFull
+from pydantic import AnyUrl
+
+GITHUB_OAUTH_CLIENT_ID = getenv("GITHUB_OAUTH_CLIENT_ID")
+GITHUB_OAUTH_CLIENT_SECRET = getenv("GITHUB_OAUTH_CLIENT_SECRET")
+GITHUB_OAUTH_BASE_URL = getenv("GITHUB_OAUTH_BASE_URL")
+
+
+class APIKeyVerifier(TokenVerifier):
+    """Verifies requests using a static GitHub personal access token."""
+
+    def __init__(self, valid_api_keys: str):
+        super().__init__()
+        self.valid_api_keys = valid_api_keys
+
+    async def verify_token(self, token: str) -> Optional[AccessToken]:
+        if hmac.compare_digest(token, self.valid_api_keys):
+            return AccessToken(
+                token=token,
+                client_id="github_token",
+                expires_at=None,  # API keys don't expire
+                scopes=["api:read", "api:write"],
+                claims={"authenticated": True},
+            )
+        return None
+
+
+def get_oauth_verifier():
+    """Return a PermissiveGitHubProvider instance for OAuth2 authentication.
+
+    Requires GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, and
+    GITHUB_OAUTH_BASE_URL to be set.
+    """
+    from fastmcp.server.auth.providers.github import GitHubProvider
+
+    if not all([GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, GITHUB_OAUTH_BASE_URL]):
+        raise ValueError(
+            "GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, and "
+            "GITHUB_OAUTH_BASE_URL must all be set to use OAuth2 auth"
+        )
+
+    class _PermissiveGitHubProvider(GitHubProvider):
+        """GitHubProvider that accepts the upstream client_id without prior DCR.
+
+        Claude.ai and similar MCP clients skip Dynamic Client Registration and
+        send the GitHub OAuth App's client_id directly in /authorize requests.
+        On first use, this subclass auto-registers that client_id in the proxy's
+        client store so the full OAuth flow can proceed normally.
+        """
+
+        async def get_client(self, client_id: str):
+            client = await super().get_client(client_id)
+            if client is not None:
+                return client
+
+            if client_id == self._upstream_client_id:
+                logging.info(
+                    "Auto-registering upstream client_id %s (MCP client skipped DCR)",
+                    client_id,
+                )
+                await self.register_client(
+                    OAuthClientInformationFull(
+                        client_id=client_id,
+                        client_id_issued_at=int(time.time()),
+                        redirect_uris=[AnyUrl("http://localhost")],
+                        grant_types=["authorization_code", "refresh_token"],
+                        response_types=["code"],
+                    )
+                )
+                return await self._client_store.get(key=client_id)
+
+            return None
+
+    return _PermissiveGitHubProvider(
+        client_id=GITHUB_OAUTH_CLIENT_ID,
+        client_secret=GITHUB_OAUTH_CLIENT_SECRET,
+        base_url=GITHUB_OAUTH_BASE_URL,
+        required_scopes=["repo", "read:org", "user"],
+    )
+
+
+def resolve_token(github_token: Optional[str], oauth_mode: bool) -> str:
+    """Return the token to use for the current request.
+
+    In OAuth2 mode, reads the authenticated user's token from FastMCP's
+    per-request context. Falls back to the static github_token in all other
+    cases (stdio mode or API-key mode).
+
+    Raises:
+        RuntimeError: In OAuth2 mode when no access token is available in the
+            request context and no GITHUB_TOKEN fallback is configured.
+    """
+    if oauth_mode:
+        from fastmcp.server.dependencies import get_access_token
+
+        access_token = get_access_token()
+        if access_token is not None:
+            return access_token.token
+        if not github_token:
+            raise RuntimeError(
+                "OAuth2 mode: no access token in request context and no GITHUB_TOKEN fallback"
+            )
+    return github_token or ""

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -292,7 +292,7 @@ class GitHubIntegration:
                 timeout=TIMEOUT,
             )
             if not response.ok:
-                self._handle_response_error(response, f"PR #{pr_number} diff")
+                self._handle_response_error(response, f"PR #{pr_number} diff in {repo_owner}/{repo_name}")
 
             logging.info("Successfully fetched PR diff/patch")
             return response.text
@@ -324,7 +324,7 @@ class GitHubIntegration:
                 pr_url, headers=self._get_headers(), timeout=TIMEOUT
             )
             if not response.ok:
-                self._handle_response_error(response, f"PR #{pr_number}")
+                self._handle_response_error(response, f"PR #{pr_number} in {repo_owner}/{repo_name}")
 
             pr_data = response.json()
 
@@ -372,7 +372,7 @@ class GitHubIntegration:
                 timeout=TIMEOUT,
             )
             if not response.ok:
-                self._handle_response_error(response, f"PR #{pr_number} comment")
+                self._handle_response_error(response, f"PR #{pr_number} comment in {repo_owner}/{repo_name}")
 
             logging.info("Comment added successfully")
             return response.json()
@@ -553,7 +553,7 @@ class GitHubIntegration:
         self,
         repo_owner: str,
         issue: Literal["pr", "issue"] = "pr",
-        filtering: Literal["user", "owner", "involves"] = "involves",
+        filtering: Literal["user", "org", "repo", "involves"] = "involves",
         per_page: Annotated[int, "Number of results per page (1-100)"] = 50,
         page: int = 1,
     ) -> Dict[str, Any]:
@@ -562,7 +562,7 @@ class GitHubIntegration:
         Args:
             repo_owner (str): The owner of the repository.
             issue (Literal['pr', 'issue']): The type of items to list, either 'pr' for pull requests or 'issue' for issues. Defaults to 'pr'.
-            filtering (Literal['user', 'owner', 'involves']): The filtering criteria for the search. Defaults to 'involves'.
+            filtering (Literal['user', 'org', 'repo', 'involves']): The filtering criteria for the search. Use 'user' for a GitHub username, 'org' for an organisation, 'repo' for an owner/repo string (e.g. 'jlowin/fastmcp'), or 'involves' for a username. Defaults to 'involves'.
             per_page (Annotated[int, "Number of results per page (1-100)"]): The number of results to return per page, range 1-100. Defaults to 50.
             page (int): The page number to retrieve. Defaults to 1.
         Returns:
@@ -682,24 +682,35 @@ class GitHubIntegration:
         merge_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/merge"
 
         try:
+            payload: Dict[str, Any] = {"merge_method": merge_method}
+            if commit_title is not None:
+                payload["commit_title"] = commit_title
+            if commit_message is not None:
+                payload["commit_message"] = commit_message
+
             response = requests.put(
                 merge_url,
                 headers=self._get_headers(),
-                json={
-                    "commit_title": commit_title,
-                    "commit_message": commit_message,
-                    "merge_method": merge_method,
-                },
+                json=payload,
                 timeout=TIMEOUT,
             )
-            response.raise_for_status()
+            if not response.ok:
+                self._handle_response_error(
+                    response,
+                    f"PR #{pr_number} merge in {repo_owner}/{repo_name}",
+                )
             merge_data = response.json()
 
             logging.info("PR merged successfully")
             return merge_data
 
-        except Exception as e:
-            logging.error({"status": "error", "message": str(e)})
+        except GitHubAPIError as e:
+            github_msg = (e.response_body or {}).get("message", "") if e.response_body else ""
+            detail = github_msg or e.message
+            logging.error(f"Error merging PR: {detail}")
+            return {"status": "error", "message": detail, "details": e.response_body}
+        except requests.RequestException as e:
+            logging.error(f"Error merging PR: {str(e)}")
             traceback.print_exc()
             return {"status": "error", "message": str(e)}
 
@@ -827,6 +838,23 @@ class GitHubIntegration:
             )
             response.raise_for_status()
             issue_data = response.json()
+
+            # GitHub silently drops assignees it cannot apply (non-collaborators, unknown users).
+            # Compare requested vs actually assigned and surface any discrepancy.
+            actual_logins = {u["login"] for u in issue_data.get("assignees", [])}
+            requested = set(assignees)
+            missing = requested - actual_logins
+
+            if missing:
+                logging.warning(f"Some assignees were not applied: {missing}")
+                return {
+                    "status": "partial",
+                    "message": f"The following assignees could not be applied (not a collaborator or user does not exist): {sorted(missing)}",
+                    "assignees_requested": sorted(requested),
+                    "assignees_applied": sorted(actual_logins),
+                    "issue": issue_data,
+                }
+
             logging.info("Assignees updated successfully")
             return issue_data
         except Exception as e:
@@ -846,12 +874,7 @@ class GitHubIntegration:
             Logs errors and warnings if the request fails, the response is invalid, or no commits are found.
             Returns None in case of exceptions or if the repository has no commits.
         """
-        logging.info(
-            {
-                "status": "info",
-                "message": f"Fetching latest commit SHA for {repo_owner}/{repo_name}",
-            }
-        )
+        logging.info(f"Fetching latest commit SHA for {repo_owner}/{repo_name}")
 
         # Construct the commits URL
         commits_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/commits"
@@ -866,17 +889,10 @@ class GitHubIntegration:
 
             if commits_data:
                 latest_sha = commits_data[0]["sha"]
-                logging.info(
-                    {"status": "info", "message": f"Latest commit SHA: {latest_sha}"}
-                )
+                logging.info(f"Latest commit SHA: {latest_sha}")
                 return latest_sha
             else:
-                logging.warning(
-                    {
-                        "status": "warning",
-                        "message": "No commits found in the repository",
-                    }
-                )
+                logging.warning("No commits found in the repository")
                 return "No commits found in the repository"
 
         except Exception as e:

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -19,14 +19,20 @@
 
 from __future__ import annotations
 
-import hmac
 import logging
 import requests
 import traceback
-from fastmcp.server.auth import TokenVerifier, AccessToken
 from os import getenv
 from typing import Annotated, Any, Dict, Optional, Literal, TypedDict
 
+from .auth import (
+    APIKeyVerifier,
+    get_oauth_verifier,
+    resolve_token,
+    GITHUB_OAUTH_CLIENT_ID,
+    GITHUB_OAUTH_CLIENT_SECRET,
+    GITHUB_OAUTH_BASE_URL,
+)
 from .exceptions import (
     GitHubAPIError,
     GitHubAuthError,
@@ -36,23 +42,6 @@ from .exceptions import (
 )
 from .graphql_client import GraphQLClient
 from .graphql_queries import SEARCH_USER_QUERY, USER_CONTRIBUTIONS_QUERY
-
-
-class APIKeyVerifier(TokenVerifier):
-    def __init__(self, valid_api_keys: str):
-        super().__init__()
-        self.valid_api_keys = valid_api_keys
-
-    async def verify_token(self, token: str) -> Optional[AccessToken]:
-        if hmac.compare_digest(token, self.valid_api_keys):
-            return AccessToken(
-                token=token,
-                client_id="github_token",
-                expires_at=None,  # API keys don't expire
-                scopes=["api:read", "api:write"],
-                claims={"authenticated": True},
-            )
-        return None
 
 
 # TypedDict definitions for common return types
@@ -149,22 +138,45 @@ logging.basicConfig(level=logging.WARNING)
 class GitHubIntegration:
     def __init__(self):
         """
-        Initialises the GitHubIntegration instance by setting up the GitHub token from environment variables.
+        Initialises the GitHubIntegration instance.
+
+        In static-token mode, GITHUB_TOKEN must be set.
+        In OAuth2 mode (all three GITHUB_OAUTH_* vars set), GITHUB_TOKEN is optional —
+        per-request tokens are resolved from the OAuth2 flow via _resolve_token().
+
         Returns:
             None
         Error Handling:
-            Raises ValueError if the GITHUB_TOKEN environment variable is not set.
+            Raises ValueError if neither OAuth2 mode is active nor GITHUB_TOKEN is set.
         """
         self.github_token = GITHUB_TOKEN
-        self.verifier = APIKeyVerifier(self.github_token)
         self.base_url = "https://api.github.com"
-        if not self.github_token:
+
+        # Detect OAuth2 mode first so the token check can be conditional
+        self._oauth_mode = bool(
+            GITHUB_OAUTH_CLIENT_ID and GITHUB_OAUTH_CLIENT_SECRET and GITHUB_OAUTH_BASE_URL
+        )
+
+        # GITHUB_TOKEN is required only in static-token (non-OAuth2) mode
+        if not self._oauth_mode and not self.github_token:
             raise ValueError("Missing GitHub GITHUB_TOKEN in environment variables")
 
-        # Initialise GraphQL client
-        self.graphql = GraphQLClient(self.github_token, timeout=TIMEOUT)
+        # APIKeyVerifier only used in static-token mode
+        self.verifier = APIKeyVerifier(self.github_token) if self.github_token else None
+
+        # GraphQL client: token overridden per-call in OAuth2 mode via _resolve_token()
+        self.graphql = GraphQLClient(self.github_token or "", timeout=TIMEOUT)
 
         logging.info("GitHub Integration Initialised")
+
+    @property
+    def _oauth_verifier(self):
+        """Returns a GitHubProvider instance for OAuth2 authentication."""
+        return get_oauth_verifier()
+
+    def _resolve_token(self) -> str:
+        """Return the token for the current request."""
+        return resolve_token(self.github_token, self._oauth_mode)
 
     def _handle_response_error(self, response: requests.Response, context: str = ""):
         """
@@ -234,10 +246,11 @@ class GitHubIntegration:
         Error Handling:
             Raises ValueError if the GitHub token is not set.
         """
-        if not self.github_token:
+        token = self._resolve_token()
+        if not token:
             raise ValueError("GitHub token is missing for API requests")
         headers = {
-            "Authorization": f"token {self.github_token}",
+            "Authorization": f"token {token}",
             "Accept": "application/vnd.github.v3+json",
         }
         return headers
@@ -1013,7 +1026,9 @@ class GitHubIntegration:
 
         try:
             result = self.graphql.execute_query(
-                SEARCH_USER_QUERY, variables={"username": username}
+                SEARCH_USER_QUERY,
+                variables={"username": username},
+                token=self._resolve_token(),
             )
 
             user_data = result.get("user")
@@ -1120,6 +1135,7 @@ class GitHubIntegration:
             result = self.graphql.execute_query(
                 USER_CONTRIBUTIONS_QUERY,
                 variables=variables,
+                token=self._resolve_token(),
             )
 
             user_data = result.get("user")

--- a/src/mcp_github/graphql_client.py
+++ b/src/mcp_github/graphql_client.py
@@ -62,6 +62,7 @@ class GraphQLClient:
         self,
         query: str,
         variables: Optional[dict[str, Any]] = None,
+        token: Optional[str] = None,
     ) -> dict[str, Any]:
         """
         Execute a GraphQL query against the GitHub API.
@@ -83,11 +84,14 @@ class GraphQLClient:
         if variables:
             payload["variables"] = variables
 
+        per_call_headers = {"Authorization": f"Bearer {token}"} if token else {}  # empty string is falsy → no override
+
         try:
             logger.debug(f"Executing GraphQL query with variables: {variables}")
             response = self.session.post(
                 self.GRAPHQL_URL,
                 json=payload,
+                headers=per_call_headers,
                 timeout=self.timeout,
             )
 

--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -37,6 +37,7 @@ from fastmcp.server.middleware.caching import (
     ResponseCachingMiddleware,
 )
 from fastmcp.server.providers.skills import SkillsDirectoryProvider
+from .auth import GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, GITHUB_OAUTH_BASE_URL
 from .github_integration import GitHubIntegration as GI
 from .ip_integration import IPIntegration as IP
 
@@ -84,9 +85,16 @@ class PRIssueAnalyser:
         self.ip = IP()
 
         # Initialise MCP Server
+        def _select_auth():
+            if not MCP_ENABLE_REMOTE:
+                return None
+            if GITHUB_OAUTH_CLIENT_ID and GITHUB_OAUTH_CLIENT_SECRET and GITHUB_OAUTH_BASE_URL:
+                return self.gi._oauth_verifier  # OAuth2 path
+            return self.gi.verifier  # Default: API key / Bearer token
+
         self.mcp = FastMCP(
             name="GitHub PR and Issue Analyser",
-            auth=self.gi.verifier if MCP_ENABLE_REMOTE else None,
+            auth=_select_auth(),
             instructions="""
           # GitHub PR and Issue Analyser
 
@@ -143,10 +151,11 @@ class PRIssueAnalyser:
         self.mcp.add_provider(SkillsDirectoryProvider(Path(__file__).parent / "skills"))
 
     def register_tools(self, methods: Any = None) -> None:
-        for name, method in inspect.getmembers(methods):
-            if (
-                inspect.isfunction(method) or inspect.ismethod(method)
-            ) and not name.startswith("_"):
+        for name in dir(methods):
+            if name.startswith("_"):
+                continue
+            method = getattr(methods, name)
+            if inspect.isfunction(method) or inspect.ismethod(method):
                 self.mcp.add_tool(method)
 
     def run(self):


### PR DESCRIPTION
Add GitHub OAuth2 as a switchable auth mode alongside the existing static `GITHUB_TOKEN` path.

### Auth mode selection

| Env vars set | Auth provider | Token used for API calls |
|---|---|---|
| `GITHUB_TOKEN` only | `APIKeyVerifier` | Static `GITHUB_TOKEN` (unchanged) |
| `GITHUB_TOKEN` + all `GITHUB_OAUTH_*` | `GitHubProvider` (OAuth2) | Per-user token from FastMCP request context |
| All `GITHUB_OAUTH_*` (no `GITHUB_TOKEN`) | `GitHubProvider` (OAuth2) | Per-user token only |

### New file

| File | What |
|---|---|
| `src/mcp_github/auth.py` | `APIKeyVerifier` (moved), `get_oauth_verifier()`, `resolve_token()` |

`get_oauth_verifier()` wraps FastMCP's `GitHubProvider` with `_PermissiveGitHubProvider` — auto-registers the upstream `client_id` for MCP clients that skip DCR (e.g. Claude.ai).

### Changed files

| File | Change |
|---|---|
| `github_integration.py` | `_oauth_mode` flag; `_resolve_token()` delegates to `auth.py`; `_get_headers()` + GraphQL calls use resolved token |
| `graphql_client.py` | `execute_query()` accepts optional `token` param for per-call auth header override |
| `issues_pr_analyser.py` | `_select_auth()` picks verifier based on env config |
| `Dockerfile` / `deployment` | `FASTMCP_HOME=/tmp` for K8s read-only fs |

### Bug fixes (commit 2)

| Area | Fix |
|---|---|
| `merge_pr` | Strip null `commit_title`/`commit_message` from payload; use `_handle_response_error` instead of `raise_for_status` |
| `update_assignees` | Detect silently-dropped assignees; return `status=partial` |
| `list_open_issues_prs` | Replace invalid `owner` qualifier with `org`/`repo` |
| Error context | Add `repo_owner/repo_name` to `get_pr_diff`, `get_pr_content`, `add_pr_comments` errors |
| Logging | Replace dict-in-`logging.info()` with f-strings |
| `register_tools` | `dir()`+`getattr()` instead of `inspect.getmembers()` to avoid triggering property descriptors |

### Breaking change

`list_open_issues_prs`: `filtering="owner"` → `filtering="org"` or `filtering="repo"`.

### Test plan

- [x] `GITHUB_TOKEN` only — all tools work as before
- [x] All `GITHUB_OAUTH_*` vars + `MCP_ENABLE_REMOTE=true` — OAuth redirect flow works
- [x] Partial `GITHUB_OAUTH_*` vars — clear `ValueError`
- [x] `ruff check . --fix` clean