### PR TITLE
chore(refactor): reduce codebase size and complexity

### DIFF
--- a/src/mcp_github/auth.py
+++ b/src/mcp_github/auth.py
@@ -59,7 +59,7 @@ class APIKeyVerifier(TokenVerifier):
             return AccessToken(
                 token=token,
                 client_id="github_token",
-                expires_at=None,  # API keys don't expire
+                expires_at=None,
                 scopes=["api:read", "api:write"],
                 claims={"authenticated": True},
             )
@@ -67,13 +67,7 @@ class APIKeyVerifier(TokenVerifier):
 
 
 class _PermissiveGitHubProvider(GitHubProvider):
-    """GitHubProvider that accepts the upstream client_id without prior DCR.
-
-    Claude.ai and similar MCP clients skip Dynamic Client Registration and
-    send the GitHub OAuth App's client_id directly in /authorize requests.
-    On first use, this subclass auto-registers that client_id in the proxy's
-    client store so the full OAuth flow can proceed normally.
-    """
+    """GitHubProvider that auto-registers the upstream client_id when MCP clients skip DCR."""
 
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
         client = await super().get_client(client_id)
@@ -81,10 +75,7 @@ class _PermissiveGitHubProvider(GitHubProvider):
             return client
 
         if client_id == self._upstream_client_id:
-            logging.info(
-                "Auto-registering upstream client_id %s (MCP client skipped DCR)",
-                client_id,
-            )
+            logging.info("Auto-registering upstream client_id %s (MCP client skipped DCR)", client_id)
             await self.register_client(
                 OAuthClientInformationFull(
                     client_id=client_id,
@@ -99,22 +90,17 @@ class _PermissiveGitHubProvider(GitHubProvider):
         return None
 
 
-def _parse_redis_db(path: str) -> int:
-    """Parse the database index from a Redis URI path component."""
-    db_path = path.lstrip("/")
-    if db_path and not db_path.isdigit():
-        raise ValueError(f"Invalid Redis database in URI: {db_path!r} (must be a non-negative integer)")
-    return int(db_path) if db_path else 0
-
-
 def _build_redis_client(host_port: str) -> AsyncRedis:
     """Build an AsyncRedis client from a host:port string or Redis URI."""
     uri = host_port if "://" in host_port else f"redis://{host_port}"
     parsed = urlparse(uri)
+    db_path = parsed.path.lstrip("/")
+    if db_path and not db_path.isdigit():
+        raise ValueError(f"Invalid Redis database in URI: {db_path!r} (must be a non-negative integer)")
     return AsyncRedis(
         host=parsed.hostname or "localhost",
         port=parsed.port or 6379,
-        db=_parse_redis_db(parsed.path),
+        db=int(db_path) if db_path else 0,
         password=parsed.password or REDIS_PASSWORD or None,
         ssl=parsed.scheme == "rediss",
         decode_responses=True,
@@ -122,25 +108,7 @@ def _build_redis_client(host_port: str) -> AsyncRedis:
 
 
 def build_token_store() -> AsyncKeyValue:
-    """
-    Return a token store for OAuth state.
-
-    When REDIS_HOST_PORT is set, returns a RedisStore whose collection names are
-    prefixed with a 12-char SHA-256 hash of GITHUB_OAUTH_BASE_URL. Two server
-    instances sharing the same Redis instance will have fully isolated keyspaces
-    provided their base URLs differ.
-
-    When REDIS_HOST_PORT is unset, returns an in-process MemoryStore. No tokens
-    are written to disk in either case. Sessions are lost on server restart in
-    MemoryStore mode.
-
-    REDIS_HOST_PORT accepts either a bare host:port or a full URI:
-      redis://[:<password>@]<host>:<port>[/<db>]   — plaintext
-      rediss://[:<password>@]<host>:<port>[/<db>]  — TLS
-    REDIS_PASSWORD is used as a fallback when not embedded in the URI.
-    The database defaults to 0 when not specified in the URI.
-
-    """
+    """Return a token store for OAuth state. MemoryStore by default; RedisStore when REDIS_HOST_PORT is set."""
     if REDIS_HOST_PORT:
         store: AsyncKeyValue = RedisStore(client=_build_redis_client(REDIS_HOST_PORT))
         if GITHUB_OAUTH_BASE_URL:
@@ -151,48 +119,19 @@ def build_token_store() -> AsyncKeyValue:
 
 
 def _derive_jwt_signing_key() -> bytes:
-    """
-    Return a stable JWT signing key.
-
-    Priority:
-    1. ``JWT_SIGNING_KEY`` env var (explicit override).
-    2. Deterministic derivation from ``GITHUB_OAUTH_CLIENT_SECRET``
-       (automatic — all pods with the same secret share the same key).
-
-    When the automatic path is used, rotating the GitHub OAuth App
-    secret invalidates all stored sessions and forces clients to
-    re-authenticate.
-
-    """
+    """Return a stable JWT signing key from JWT_SIGNING_KEY or GITHUB_OAUTH_CLIENT_SECRET."""
     if JWT_SIGNING_KEY:
-        return derive_jwt_key(
-            low_entropy_material=JWT_SIGNING_KEY,
-            salt="fastmcp-jwt-signing-key",
-        )
-    return derive_jwt_key(
-        high_entropy_material=GITHUB_OAUTH_CLIENT_SECRET,  # type: ignore[arg-type]
-        salt="fastmcp-jwt-signing-key",
-    )
+        return derive_jwt_key(low_entropy_material=JWT_SIGNING_KEY, salt="fastmcp-jwt-signing-key")
+    return derive_jwt_key(high_entropy_material=GITHUB_OAUTH_CLIENT_SECRET, salt="fastmcp-jwt-signing-key")  # type: ignore[arg-type]
 
 
 def get_oauth_verifier() -> _PermissiveGitHubProvider:
-    """Return a PermissiveGitHubProvider instance for OAuth2 authentication.
-
-    Requires GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, and
-    GITHUB_OAUTH_BASE_URL to be set.
-
-    JWT_SIGNING_KEY is optional. When omitted, a stable key is derived
-    automatically from GITHUB_OAUTH_CLIENT_SECRET so all pods generate
-    the same signing key without requiring an additional env var.
-
-    """
+    """Return a PermissiveGitHubProvider instance for OAuth2 authentication."""
     if not all((GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, GITHUB_OAUTH_BASE_URL)):
         raise ValueError(
-            "GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, and "
-            "GITHUB_OAUTH_BASE_URL must all be set to use OAuth2 auth"
+            "GITHUB_OAUTH_CLIENT_ID, GITHUB_OAUTH_CLIENT_SECRET, and GITHUB_OAUTH_BASE_URL must all be set"
         )
 
-    # Validate types after check (pyright doesn't narrow through all() check)
     return _PermissiveGitHubProvider(
         client_id=GITHUB_OAUTH_CLIENT_ID,  # type: ignore[arg-type]
         client_secret=GITHUB_OAUTH_CLIENT_SECRET,  # type: ignore[arg-type]
@@ -204,20 +143,7 @@ def get_oauth_verifier() -> _PermissiveGitHubProvider:
 
 
 def resolve_token(github_token: str | None, oauth_mode: bool) -> str:
-    """
-    Return the token to use for the current request.
-
-    In OAuth2 mode, reads the authenticated user's token from FastMCP's
-    per-request context. Falls back to the static github_token in all other
-    cases (stdio mode or API-key mode).
-
-    Raises
-    ------
-    RuntimeError
-        In OAuth2 mode when no access token is available in
-        the request context and no GITHUB_TOKEN fallback is configured.
-
-    """
+    """Return the token for the current request."""
     if oauth_mode:
         access_token = get_access_token()
         if access_token is not None:

--- a/src/mcp_github/exceptions.py
+++ b/src/mcp_github/exceptions.py
@@ -16,27 +16,13 @@
 #  * limitations under the License.
 #  */
 
-"""
-Custom exceptions for MCP GitHub integration.
-
-This module defines a hierarchy of exceptions for handling errors from
-GitHub API and IP info services in a structured way.
-"""
+"""Custom exceptions for MCP GitHub integration."""
 
 from __future__ import annotations
 
 
 class MCPGitHubError(Exception):
     """Base exception for MCP GitHub integration."""
-
-    def __init__(self, message: str, code: str = "ERROR"):
-        """Initialize MCPGitHubError."""
-        super().__init__(message)
-        self.message = message
-        self.code = code
-
-    def __str__(self) -> str:
-        return f"[{self.code}] {self.message}"
 
 
 class GitHubAPIError(MCPGitHubError):
@@ -49,67 +35,36 @@ class GitHubAPIError(MCPGitHubError):
         response_body: dict | None = None,
         code: str = "GITHUB_API_ERROR",
     ):
-        super().__init__(message, code)
+        prefix = f"[{code}] HTTP {status_code}: " if status_code else f"[{code}] "
+        super().__init__(f"{prefix}{message}")
         self.status_code = status_code
         self.response_body = response_body
-
-    def __str__(self) -> str:
-        if self.status_code:
-            return f"[{self.code}] HTTP {self.status_code}: {self.message}"
-        return super().__str__()
+        self.code = code
 
 
 class GitHubAuthError(GitHubAPIError):
-    # fmt: off
-
-    """
-    Authentication failed (401).
-
-    Inherits from GitHubAPIError because a 401 response is still an HTTP API
-    response -- it follows the same status_code + response_body pattern.
-    """
-
-    # fmt: on
-
     def __init__(
-        self,
-        message: str = "Authentication failed. Check your GitHub token.",
-        response_body: dict | None = None,
+        self, message: str = "Authentication failed. Check your GitHub token.", response_body: dict | None = None
     ):
-        """Initialize GitHubAuthError."""
         super().__init__(message, status_code=401, response_body=response_body, code="AUTH_FAILED")
 
 
 class GitHubRateLimitError(GitHubAPIError):
-    """Rate limit exceeded (403)."""
-
     def __init__(
         self,
         message: str = "GitHub API rate limit exceeded.",
         response_body: dict | None = None,
         reset_timestamp: int | None = None,
     ):
-        """Initialize GitHubRateLimitError."""
         super().__init__(message, status_code=403, response_body=response_body, code="RATE_LIMITED")
         self.reset_timestamp = reset_timestamp
 
 
 class GitHubNotFoundError(GitHubAPIError):
-    """Resource not found (404)."""
-
     def __init__(self, message: str, response_body: dict | None = None):
-        """Initialize GitHubNotFoundError."""
         super().__init__(message, status_code=404, response_body=response_body, code="NOT_FOUND")
 
 
 class GitHubValidationError(GitHubAPIError):
-    """Validation failed (422)."""
-
     def __init__(self, message: str = "Validation failed.", response_body: dict | None = None):
-        """Initialize GitHubValidationError."""
-        super().__init__(
-            message,
-            status_code=422,
-            response_body=response_body,
-            code="VALIDATION_ERROR",
-        )
+        super().__init__(message, status_code=422, response_body=response_body, code="VALIDATION_ERROR")

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -242,7 +242,7 @@ class GitHubIntegration:
             return response
         except GitHubAuthError:
             raise
-        except httpx.HTTPError as e:
+        except Exception as e:
             raise ToolError(str(e)) from e
 
     @_read_only
@@ -316,7 +316,7 @@ class GitHubIntegration:
         head: str,
         base: str,
         draft: bool = False,
-    ) -> PRContent:
+    ) -> dict[str, Any]:
         """Creates a new pull request."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls"
         data = self._request(
@@ -325,7 +325,7 @@ class GitHubIntegration:
             context=f"create PR {head} -> {base}",
             json={"title": title, "body": body, "head": head, "base": base, "draft": draft},
         ).json()
-        return {  # pyright: ignore[reportReturnType]
+        return {
             "pr_url": data.get("html_url"),
             "pr_number": data.get("number"),
             "status": data.get("state"),

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -598,14 +598,14 @@ class GitHubIntegration:
         until: str = "",
         max_results: int = 50,
     ) -> UserActivityResult:
-        """Get user activities with optional filtering by org, repo, and date range using GraphQL API."""
+        """Get user activities with optional filtering by org, repo, and date range using GraphQL API. since/until accept YYYY-MM-DD or full ISO 8601 (YYYY-MM-DDTHH:MM:SSZ)."""
         logger.info(f"Fetching user activities for {username} (org={org}, repo={repo}, since={since}, until={until})")
         try:
             variables: dict[str, Any] = {"username": username}
             if since:
-                variables["since"] = since
+                variables["since"] = since + "T00:00:00Z" if len(since) == 10 else since
             if until:
-                variables["until"] = until
+                variables["until"] = until + "T23:59:59Z" if len(until) == 10 else until
             result = self.graphql.execute_query(
                 USER_CONTRIBUTIONS_QUERY,
                 variables=variables,
@@ -618,8 +618,8 @@ class GitHubIntegration:
             date_range = None
             if since or until:
                 date_range = {
-                    "since": since if since else collection.get("startedAt", ""),
-                    "until": until if until else collection.get("endedAt", ""),
+                    "since": variables.get("since", collection.get("startedAt", "")),
+                    "until": variables.get("until", collection.get("endedAt", "")),
                 }
             commits = []
             pull_requests = []

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -44,102 +44,74 @@ from .exceptions import (
 from .graphql_client import GraphQLClient
 from .graphql_queries import PR_LINKED_ISSUES_QUERY, PR_STATUS_CHECKS_QUERY, SEARCH_USER_QUERY, USER_CONTRIBUTIONS_QUERY
 
-# TypedDict definitions for common return types (PEP 695 type alias syntax)
-type PRContent = TypedDict(
-    "PRContent",
-    {  # pyright: ignore[reportInvalidTypeForm]
-        "title": str,
-        "description": str | None,
-        "author": str,
-        "created_at": str,
-        "updated_at": str,
-        "state": str,
-    },
-)
+
+class PRContent(TypedDict):
+    title: str
+    description: str | None
+    author: str
+    created_at: str
+    updated_at: str
+    state: str
 
 
-type CommentData = TypedDict(
-    "CommentData",
-    {  # pyright: ignore[reportInvalidTypeForm]
-        "id": int,
-        "body": str,
-        "user": dict[str, Any],
-        "created_at": str,
-        "updated_at": str,
-    },
-)
+class CommentData(TypedDict):
+    id: int
+    body: str
+    user: dict[str, Any]
+    created_at: str
+    updated_at: str
 
 
-type IssueData = TypedDict(
-    "IssueData",
-    {  # pyright: ignore[reportInvalidTypeForm]
-        "id": int,
-        "number": int,
-        "title": str,
-        "body": str | None,
-        "state": str,
-        "user": dict[str, Any],
-        "created_at": str,
-        "updated_at": str,
-        "labels": list[dict[str, Any]],
-    },
-)
+class IssueData(TypedDict):
+    id: int
+    number: int
+    title: str
+    body: str | None
+    state: str
+    user: dict[str, Any]
+    created_at: str
+    updated_at: str
+    labels: list[dict[str, Any]]
 
 
-type UserSearchResult = TypedDict(
-    "UserSearchResult",
-    {  # pyright: ignore[reportInvalidTypeForm]
-        "login": str,
-        "name": str | None,
-        "email": str | None,
-        "company": str | None,
-        "location": str | None,
-        "bio": str | None,
-        "url": str,
-        "avatar_url": str | None,
-        "created_at": str,
-        "updated_at": str,
-        "followers": int,
-        "following": int,
-        "public_repos": int,
-        "recent_repos": list[dict[str, Any]],
-        "organizations": list[dict[str, Any]],
-    },
-)
+class UserSearchResult(TypedDict):
+    login: str
+    name: str | None
+    email: str | None
+    company: str | None
+    location: str | None
+    bio: str | None
+    url: str
+    avatar_url: str | None
+    created_at: str
+    updated_at: str
+    followers: int
+    following: int
+    public_repos: int
+    recent_repos: list[dict[str, Any]]
+    organizations: list[dict[str, Any]]
 
 
-type UserActivityResult = TypedDict(
-    "UserActivityResult",
-    {  # pyright: ignore[reportInvalidTypeForm]
-        "username": str,
-        "date_range": dict[str, str] | None,
-        "total_contributions": dict[str, int],
-        "commits": list[dict[str, Any]],
-        "pull_requests": list[dict[str, Any]],
-        "issues": list[dict[str, Any]],
-        "reviews": list[dict[str, Any]],
-    },
-)
+class UserActivityResult(TypedDict):
+    username: str
+    date_range: dict[str, str] | None
+    total_contributions: dict[str, int]
+    commits: list[dict[str, Any]]
+    pull_requests: list[dict[str, Any]]
+    issues: list[dict[str, Any]]
+    reviews: list[dict[str, Any]]
 
 
-type LinkedIssuesResult = TypedDict(
-    "LinkedIssuesResult",
-    {  # pyright: ignore[reportInvalidTypeForm]
-        "pr_number": int,
-        "linked_issues": list[dict[str, Any]],
-    },
-)
+class LinkedIssuesResult(TypedDict):
+    pr_number: int
+    linked_issues: list[dict[str, Any]]
 
 
-type StatusChecksResult = TypedDict(
-    "StatusChecksResult",
-    {  # pyright: ignore[reportInvalidTypeForm]
-        "pr_number": int,
-        "overall": str,
-        "check_runs": list[dict[str, Any]],
-        "commit_statuses": list[dict[str, Any]],
-    },
-)
+class StatusChecksResult(TypedDict):
+    pr_number: int
+    overall: str
+    check_runs: list[dict[str, Any]]
+    commit_statuses: list[dict[str, Any]]
 
 
 GITHUB_TOKEN = getenv("GITHUB_TOKEN")
@@ -149,35 +121,22 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARNING)
 
 
-def _read_only(fn: Any) -> Any:
-    fn._mcp_annotations = ToolAnnotations(readOnlyHint=True)
-    return fn
+def _annotate(*, ro: bool = False, destructive: bool = False) -> Any:
+    def deco(fn: Any) -> Any:
+        fn._mcp_annotations = ToolAnnotations(readOnlyHint=ro, destructiveHint=destructive)
+        return fn
+
+    return deco
 
 
-def _destructive(fn: Any) -> Any:
-    fn._mcp_annotations = ToolAnnotations(readOnlyHint=False, destructiveHint=True)
-    return fn
-
-
-def _write(fn: Any) -> Any:
-    fn._mcp_annotations = ToolAnnotations(readOnlyHint=False)
-    return fn
+_read_only = _annotate(ro=True)
+_write = _annotate()
+_destructive = _annotate(destructive=True)
 
 
 class GitHubIntegration:
     def __init__(self):
-        """
-        Initialises the GitHubIntegration instance.
-
-        In static-token mode, GITHUB_TOKEN must be set.
-        In OAuth2 mode (all three GITHUB_OAUTH_* vars set), GITHUB_TOKEN is optional —
-        per-request tokens are resolved from the OAuth2 flow via _resolve_token().
-
-        Returns:
-            None
-        Error Handling:
-            Raises ValueError if neither OAuth2 mode is active nor GITHUB_TOKEN is set.
-        """
+        """Initialises the GitHubIntegration instance."""
         self.github_token = GITHUB_TOKEN
 
         # Detect OAuth2 mode first so the token check can be conditional
@@ -204,28 +163,8 @@ class GitHubIntegration:
         """Return the token for the current request."""
         return resolve_token(self.github_token, self._oauth_mode)
 
-    def _auth_error_msg(self) -> str:
-        """Return a 401 error message, appending a re-auth hint in OAuth mode."""
-        msg = "Authentication failed. Check your GitHub token."
-        if self._oauth_mode:
-            msg += " The GitHub OAuth authorization may have been revoked — please re-authenticate via the OAuth flow."
-        return msg
-
     def _handle_response_error(self, response: httpx.Response, context: str = ""):
-        """
-        Handle HTTP errors from GitHub API with specific exceptions.
-
-        Args:
-            response: The httpx Response object
-            context: Additional context for error messages
-
-        Raises:
-            GitHubAuthError: For 401 responses
-            GitHubRateLimitError: For 403 rate limit responses
-            GitHubNotFoundError: For 404 responses
-            GitHubValidationError: For 422 responses
-            GitHubAPIError: For other error responses
-        """
+        """Handle HTTP errors from GitHub API with specific exceptions."""
         status = response.status_code
 
         try:
@@ -234,7 +173,12 @@ class GitHubIntegration:
             response_body = None
 
         if status == 401:
-            raise GitHubAuthError(self._auth_error_msg(), response_body=response_body)
+            msg = "Authentication failed. Check your GitHub token."
+            if self._oauth_mode:
+                msg += (
+                    " The GitHub OAuth authorization may have been revoked — please re-authenticate via the OAuth flow."
+                )
+            raise GitHubAuthError(msg, response_body=response_body)
 
         if status == 403:
             self._raise_for_403(response, response_body)
@@ -277,13 +221,7 @@ class GitHubIntegration:
             self._handle_response_error(response, context)
 
     def _get_headers(self):
-        """
-        Constructs the HTTP headers required for GitHub API requests, including the authorization token.
-        Returns:
-            dict: A dictionary containing the required HTTP headers.
-        Error Handling:
-            Raises ValueError if the GitHub token is not set.
-        """
+        """Constructs the HTTP headers required for GitHub API requests."""
         token = self._resolve_token()
         if not token:
             raise ValueError("GitHub token is missing for API requests")
@@ -293,109 +231,45 @@ class GitHubIntegration:
         }
         return headers
 
+    def _request(self, method: str, url: str, *, context: str = "", **kwargs: Any) -> httpx.Response:
+        """Make an HTTP request and handle errors."""
+        ctx = context or url
+        logger.info(f"{method.upper()} {ctx}")
+        try:
+            response = httpx.request(method, url, headers=self._get_headers(), timeout=TIMEOUT, **kwargs)
+            self._raise_for_status(response, context)
+            logger.info(f"Success {method.upper()} {ctx}")
+            return response
+        except GitHubAuthError:
+            raise
+        except httpx.HTTPError as e:
+            raise ToolError(str(e)) from e
+
     @_read_only
     def get_pr_diff(self, repo_owner: str, repo_name: str, pr_number: int) -> str:
-        """
-        Fetches the diff/patch of a specific pull request from a GitHub repository.
-        Args:
-            repo_owner (str): The owner of the GitHub repository.
-            repo_name (str): The name of the GitHub repository.
-            pr_number (int): The pull request number.
-        Returns:
-            str: The raw patch/diff text of the pull request if successful.
-        Raises:
-            GitHubNotFoundError: If the PR is not found.
-            GitHubAPIError: If the API request fails.
-        """
-        logger.info(f"Fetching PR diff for {repo_owner}/{repo_name}#{pr_number}")
-
-        try:
-            response = httpx.get(
-                f"https://patch-diff.githubusercontent.com/raw/{repo_owner}/{repo_name}/pull/{pr_number}.patch",
-                headers=self._get_headers(),
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response)
-
-            logger.info("Successfully fetched PR diff/patch")
-            return response.text
-
-        except httpx.TransportError as e:
-            raise GitHubAPIError(f"Request failed: {e}") from e
+        """Fetches the diff/patch of a specific pull request."""
+        url = f"https://patch-diff.githubusercontent.com/raw/{repo_owner}/{repo_name}/pull/{pr_number}.patch"
+        return self._request("GET", url, context=f"PR #{pr_number} diff").text
 
     @_read_only
     def get_pr_content(self, repo_owner: str, repo_name: str, pr_number: int) -> PRContent:
-        """
-        Fetches the content/details of a specific pull request from a GitHub repository.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            pr_number (int): The pull request number.
-        Returns:
-            Dict[str, Any]: A dictionary containing the pull request's title, description, author, creation and update timestamps, and state.
-        Raises:
-            GitHubNotFoundError: If the PR is not found.
-            GitHubAPIError: If the API request fails.
-        """
-        logger.info(f"Fetching PR content for {repo_owner}/{repo_name}#{pr_number}")
-
-        pr_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
-
-        try:
-            response = httpx.get(pr_url, headers=self._get_headers(), timeout=TIMEOUT)
-            self._raise_for_status(response)
-
-            pr_data = response.json()
-
-            pr_info = {
-                "title": pr_data["title"],
-                "description": pr_data["body"],
-                "author": pr_data["user"]["login"],
-                "created_at": pr_data["created_at"],
-                "updated_at": pr_data["updated_at"],
-                "state": pr_data["state"],
-            }
-
-            logger.info("Successfully fetched PR content")
-            return pr_info
-
-        except httpx.TransportError as e:
-            raise GitHubAPIError(f"Request failed: {e}") from e
+        """Fetches the content/details of a specific pull request."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
+        data = self._request("GET", url, context=f"PR #{pr_number}").json()
+        return {
+            "title": data["title"],
+            "description": data["body"],
+            "author": data["user"]["login"],
+            "created_at": data["created_at"],
+            "updated_at": data["updated_at"],
+            "state": data["state"],
+        }
 
     @_write
     def add_pr_comments(self, repo_owner: str, repo_name: str, pr_number: int, comment: str) -> CommentData:
-        """
-        Adds a comment to a specific pull request on GitHub.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            pr_number (int): The pull request number to which the comment will be added.
-            comment (str): The content of the comment to add.
-        Returns:
-            Dict[str, Any]: The JSON response from the GitHub API containing the comment data if successful.
-        Raises:
-            GitHubNotFoundError: If the PR is not found.
-            GitHubValidationError: If the comment data is invalid.
-            GitHubAPIError: If the API request fails.
-        """
-        logger.info(f"Adding comment to PR {repo_owner}/{repo_name}#{pr_number}")
-
-        comments_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments"
-
-        try:
-            response = httpx.post(
-                comments_url,
-                headers=self._get_headers(),
-                json={"body": comment},
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response)
-
-            logger.info("Comment added successfully")
-            return response.json()
-
-        except httpx.TransportError as e:
-            raise GitHubAPIError(f"Request failed: {e}") from e
+        """Adds a comment to a specific pull request."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments"
+        return self._request("POST", url, context=f"PR #{pr_number} comment", json={"body": comment}).json()
 
     @_write
     def add_inline_pr_comment(
@@ -407,58 +281,15 @@ class GitHubIntegration:
         line: int,
         comment_body: str,
     ) -> CommentData:
-        """
-        Adds an inline review comment to a specific line in a file within a pull request on GitHub.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            pr_number (int): The pull request number.
-            path (str): The relative path to the file (e.g., 'src/main.py').
-            line (int): The line number in the file to comment on.
-            comment_body (str): The content of the review comment.
-        Returns:
-            Dict[str, Any]: The JSON response from the GitHub API containing the comment data if successful.
-            None: If an error occurs while adding the comment.
-        Error Handling:
-            Logs an error message and prints the traceback if the request fails or an exception is raised.
-        """
-        logger.info(f"Adding inline review comment to PR {repo_owner}/{repo_name}#{pr_number} on {path}:{line}")
-
-        # Construct the review comments URL
-        review_comments_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments"
-
-        try:
-            pr_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
-            pr_response = httpx.get(pr_url, headers=self._get_headers(), timeout=TIMEOUT)
-            self._raise_for_status(pr_response, f"PR #{pr_number}")
-            pr_data = pr_response.json()
-            commit_id = pr_data["head"]["sha"]
-
-            payload = {
-                "body": comment_body,
-                "commit_id": commit_id,
-                "path": path,
-                "line": line,
-                "side": "RIGHT",
-            }
-
-            response = httpx.post(
-                review_comments_url,
-                headers=self._get_headers(),
-                json=payload,
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"inline comment on {path}:{line}")
-            comment_data = response.json()
-
-            logger.info("Inline review comment added successfully")
-            return comment_data
-
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error adding inline review comment: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Adds an inline review comment to a specific line in a file within a PR."""
+        pr_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
+        pr_data = self._request("GET", pr_url, context=f"PR #{pr_number}").json()
+        commit_id = pr_data.get("head", {}).get("sha")
+        if not commit_id:
+            raise ToolError(f"Could not retrieve head SHA for PR #{pr_number}")
+        review_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments"
+        payload = {"body": comment_body, "commit_id": commit_id, "path": path, "line": line, "side": "RIGHT"}
+        return self._request("POST", review_url, context=f"inline comment on {path}:{line}", json=payload).json()
 
     @_write
     def update_pr_description(
@@ -469,42 +300,11 @@ class GitHubIntegration:
         new_title: str,
         new_description: str,
     ) -> PRContent:
-        """
-        Updates the title and description (body) of a specific pull request on GitHub.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            pr_number (int): The pull request number to update.
-            new_title (str): The new title for the pull request.
-            new_description (str): The new description (body) for the pull request.
-        Returns:
-            Dict[str, Any]: The updated pull request data as returned by the GitHub API if the update is successful.
-            None: If an error occurs during the update process.
-        Error Handling:
-            Logs an error message and prints the traceback if the update fails due to an exception (e.g., network issues, invalid credentials, or API errors).
-        """
-        logger.info(f"Updating PR description for {repo_owner}/{repo_name}#{pr_number}")
-
-        # Construct the PR URL
-        pr_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
-        try:
-            # Update the PR description
-            response = httpx.patch(
-                pr_url,
-                headers=self._get_headers(),
-                json={"title": new_title, "body": new_description},
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"PR #{pr_number}")
-            pr_data = response.json()
-
-            logger.info("PR description updated successfully")
-            return pr_data
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error updating PR description: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Updates the title and description of a specific pull request."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
+        return self._request(
+            "PATCH", url, context=f"PR #{pr_number}", json={"title": new_title, "body": new_description}
+        ).json()
 
     @_write
     def create_pr(
@@ -517,54 +317,20 @@ class GitHubIntegration:
         base: str,
         draft: bool = False,
     ) -> PRContent:
-        """
-        Creates a new pull request in the specified GitHub repository.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            title (str): The title of the pull request.
-            body (str): The body content of the pull request.
-            head (str): The name of the branch where your changes are implemented.
-            base (str): The name of the branch you want the changes pulled into.
-            draft (bool, optional): Whether the pull request is a draft. Defaults to False.
-        Returns:
-            Dict[str, Any]: The JSON response from the GitHub API containing pull request information if successful.
-        Error Handling:
-            Logs errors and prints the traceback if the pull request creation fails, returning None.
-        """
-        logger.info(f"Creating PR in {repo_owner}/{repo_name}")
-
-        pr_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls"
-
-        try:
-            response = httpx.post(
-                pr_url,
-                headers=self._get_headers(),
-                json={
-                    "title": title,
-                    "body": body,
-                    "head": head,
-                    "base": base,
-                    "draft": draft,
-                },
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"create PR {head} -> {base}")
-            pr_data = response.json()
-
-            logger.info("PR created successfully")
-            return {
-                "pr_url": pr_data.get("html_url"),
-                "pr_number": pr_data.get("number"),
-                "status": pr_data.get("state"),
-                "title": pr_data.get("title"),
-            }
-
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error creating PR: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Creates a new pull request."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls"
+        data = self._request(
+            "POST",
+            url,
+            context=f"create PR {head} -> {base}",
+            json={"title": title, "body": body, "head": head, "base": base, "draft": draft},
+        ).json()
+        return {  # pyright: ignore[reportReturnType]
+            "pr_url": data.get("html_url"),
+            "pr_number": data.get("number"),
+            "status": data.get("state"),
+            "title": data.get("title"),
+        }
 
     @_read_only
     def list_open_issues_prs(
@@ -575,98 +341,38 @@ class GitHubIntegration:
         per_page: Annotated[int, "Number of results per page (1-100)"] = 50,
         page: int = 1,
     ) -> dict[str, Any]:
-        """
-        Lists open pull requests or issues for a specified GitHub repository owner.
-        Args:
-            repo_owner (str): The owner of the repository.
-            issue (Literal['pr', 'issue']): The type of items to list, either 'pr' for pull requests or 'issue' for issues. Defaults to 'pr'.
-            filtering (Literal['user', 'org', 'repo', 'involves']): The filtering criteria for the search. Use 'user' for a GitHub username, 'org' for an organisation, 'repo' for an owner/repo string (e.g. 'jlowin/fastmcp'), or 'involves' for a username. Defaults to 'involves'.
-            per_page (Annotated[int, "Number of results per page (1-100)"]): The number of results to return per page, range 1-100. Defaults to 50.
-            page (int): The page number to retrieve. Defaults to 1.
-        Returns:
-            Dict[str, Any]: A dictionary containing the list of open pull requests or issues, depending on the value of the `issue` parameter.
-            None: If an error occurs during the request.
-        Error Handling:
-            Logs an error message and prints the traceback if the request fails or an exception is raised.
-        """
-        logger.info(f"Listing open {issue}s for {repo_owner}")
-
-        # Construct the search URL
-        search_url = f"https://api.github.com/search/issues?q=is:{issue}+is:open+{filtering}:{repo_owner}&per_page={per_page}&page={page}"
-
-        try:
-            response = httpx.get(search_url, headers=self._get_headers(), timeout=TIMEOUT)
-            self._raise_for_status(response, f"list open {issue}s for {repo_owner}")
-            pr_data = response.json()
-            open_prs = {
-                "total": pr_data["total_count"],
-                f"open_{issue}s": [
-                    {
-                        "url": item["html_url"],
-                        "title": item["title"],
-                        "number": item["number"],
-                        "state": item["state"],
-                        "created_at": item["created_at"],
-                        "updated_at": item["updated_at"],
-                        "author": item["user"]["login"],
-                        "label_names": [label["name"] for label in item.get("labels", [])],
-                        "is_draft": item.get("draft", False),
-                    }
-                    for item in pr_data["items"]
-                ],
-            }
-
-            logger.info(f"Open {issue}s listed successfully")
-            return open_prs
-
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error listing open {issue}s: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Lists open pull requests or issues."""
+        url = f"https://api.github.com/search/issues?q=is:{issue}+is:open+{filtering}:{repo_owner}&per_page={per_page}&page={page}"
+        data = self._request("GET", url, context=f"list open {issue}s for {repo_owner}").json()
+        return {
+            "total": data["total_count"],
+            f"open_{issue}s": [
+                {
+                    "url": item["html_url"],
+                    "title": item["title"],
+                    "number": item["number"],
+                    "state": item["state"],
+                    "created_at": item["created_at"],
+                    "updated_at": item["updated_at"],
+                    "author": item["user"]["login"],
+                    "label_names": [label["name"] for label in item.get("labels", [])],
+                    "is_draft": item.get("draft", False),
+                }
+                for item in data["items"]
+            ],
+        }
 
     @_write
     def create_issue(self, repo_owner: str, repo_name: str, title: str, body: str, labels: list[str]) -> IssueData:
-        """
-        Creates a new issue in the specified GitHub repository.
-        If the issue is created successfully, a link to the issue must be appended in the PR's description.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            title (str): The title of the issue to be created.
-            body (str): The body content of the issue.
-            labels (list[str]): A list of labels to assign to the issue. The label 'mcp' will always be included.
-        Returns:
-            Dict[str, Any]: A dictionary containing the created issue's data if successful.
-            None: If an error occurs during issue creation.
-        Error Handling:
-            Logs errors and prints the traceback if the issue creation fails, returning None.
-        """
-        logger.info(f"Creating issue in {repo_owner}/{repo_name}")
-
-        # Construct the issues URL
-        issues_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues"
-
-        try:
-            # Create the issue
-            issue_labels = ["mcp"] if not labels else labels + ["mcp"]
-            response = httpx.post(
-                issues_url,
-                headers=self._get_headers(),
-                json={"title": title, "body": body, "labels": issue_labels},
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"create issue in {repo_owner}/{repo_name}")
-            issue_data = response.json()
-
-            logger.info("Issue created successfully")
-            return issue_data
-
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error creating issue: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Creates a new issue."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues"
+        issue_labels = ["mcp"] if not labels else labels + ["mcp"]
+        return self._request(
+            "POST",
+            url,
+            context=f"create issue in {repo_owner}/{repo_name}",
+            json={"title": title, "body": body, "labels": issue_labels},
+        ).json()
 
     @_destructive
     def merge_pr(
@@ -678,59 +384,20 @@ class GitHubIntegration:
         commit_message: str | None = None,
         merge_method: Literal["merge", "squash", "rebase"] = "squash",
     ) -> dict[str, Any]:
-        """
-        Merges a specific pull request in a GitHub repository using the specified merge method.
-        If merge pr is fails use update_pr_branch to update the branch with the latest changes from the base branch and try merging again after CI finishes.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            pr_number (int): The pull request number to merge.
-            commit_title (str, optional): The title for the merge commit. Defaults to None.
-            commit_message (str, optional): The message for the merge commit. Defaults to None.
-            merge_method (Literal['merge', 'squash', 'rebase'], optional): The merge method to use ('merge', 'squash', or 'rebase'). Defaults to 'squash'.
-        Returns:
-            Dict[str, Any]: The JSON response from the GitHub API containing merge information if successful.
-        Error Handling:
-            Logs errors and prints the traceback if the merge fails, returning None.
-        """
-        logger.info(f"Merging PR {repo_owner}/{repo_name}#{pr_number}")
-
-        # Construct the merge URL
-        merge_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/merge"
-
+        """Merges a specific pull request."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/merge"
+        payload: dict[str, Any] = {"merge_method": merge_method}
+        if commit_title is not None:
+            payload["commit_title"] = commit_title
+        if commit_message is not None:
+            payload["commit_message"] = commit_message
         try:
-            payload: dict[str, Any] = {"merge_method": merge_method}
-            if commit_title is not None:
-                payload["commit_title"] = commit_title
-            if commit_message is not None:
-                payload["commit_message"] = commit_message
-
-            response = httpx.put(
-                merge_url,
-                headers=self._get_headers(),
-                json=payload,
-                timeout=TIMEOUT,
-            )
-            if not response.is_success:
-                self._handle_response_error(
-                    response,
-                    f"PR #{pr_number} merge in {repo_owner}/{repo_name}",
-                )
-            merge_data = response.json()
-
-            logger.info("PR merged successfully")
-            return merge_data
-
-        except GitHubAuthError:
-            raise
+            return self._request("PUT", url, context=f"PR #{pr_number} merge", json=payload).json()
         except GitHubAPIError as e:
             github_msg = (e.response_body or {}).get("message", "") if e.response_body else ""
-            detail = github_msg or e.message
+            detail = github_msg or str(e)
             logger.error(f"Error merging PR: {detail}")
             raise ToolError(detail) from e
-        except httpx.HTTPError as e:
-            logger.error(f"Error merging PR: {str(e)}")
-            raise ToolError(str(e)) from e
 
     @_write
     def update_pr_branch(
@@ -740,43 +407,12 @@ class GitHubIntegration:
         pr_number: int,
         expected_head_sha: str | None = None,
     ) -> dict[str, Any]:
-        """
-        Updates the pull request branch with the latest upstream changes by merging the base branch into the PR branch.
-
-        Args:
-            repo_owner: The owner of the repository.
-            repo_name: The name of the repository.
-            pr_number: The pull request number.
-            expected_head_sha: Optional SHA of the PR branch head. If provided, GitHub will only update the
-                branch if the current head SHA matches this value.
-        Returns:
-            dict[str, Any]: The GitHub API response for the branch update request.
-        Raises:
-            GitHubAuthError: If authentication fails.
-            GitHubAPIError: If the request fails.
-        """
-        logger.info(f"Updating PR branch for {repo_owner}/{repo_name}#{pr_number}")
-
-        pr_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/update-branch"
-
-        try:
-            payload: dict[str, Any] = {}
-            if expected_head_sha is not None:
-                payload["expected_head_sha"] = expected_head_sha
-            response = httpx.put(
-                pr_url,
-                headers=self._get_headers(),
-                json=payload,
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"PR #{pr_number} update branch")
-            logger.info("PR branch update requested successfully")
-            return response.json()
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error updating PR branch: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Updates the pull request branch with the latest upstream changes."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/update-branch"
+        payload: dict[str, Any] = {}
+        if expected_head_sha is not None:
+            payload["expected_head_sha"] = expected_head_sha
+        return self._request("PUT", url, context=f"PR #{pr_number} update branch", json=payload).json()
 
     @_write
     def update_issue(
@@ -789,44 +425,14 @@ class GitHubIntegration:
         labels: list[str] = [],
         state: Literal["open", "closed"] = "open",
     ) -> IssueData:
-        """
-        Updates an existing issue in the specified GitHub repository.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            issue_number (int): The number of the issue to update.
-            title (str): The new title for the issue.
-            body (str): The new body content for the issue.
-            labels (list[str], optional): A list of labels to assign to the issue. Defaults to an empty list.
-            state (str, optional): The state of the issue ('open' or 'closed'). Defaults to 'open'.
-        Returns:
-            Dict[str, Any]: The updated issue data as returned by the GitHub API if the update is successful.
-            None: If an error occurs during the update process.
-        Error Handling:
-            Logs an error message and prints the traceback if the request fails or an exception is raised.
-        """
-        logger.info(f"Updating issue {issue_number} in {repo_owner}/{repo_name}")
-
-        # Construct the issue URL
-        issue_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{issue_number}"
-
-        try:
-            # Update the issue
-            response = httpx.patch(
-                issue_url,
-                headers=self._get_headers(),
-                json={"title": title, "body": body, "labels": labels, "state": state},
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"issue #{issue_number}")
-            issue_data = response.json()
-            logger.info("Issue updated successfully")
-            return issue_data
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error updating issue: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Updates an existing issue."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{issue_number}"
+        return self._request(
+            "PATCH",
+            url,
+            context=f"issue #{issue_number}",
+            json={"title": title, "body": body, "labels": labels, "state": state},
+        ).json()
 
     @_write
     def update_reviews(
@@ -837,183 +443,55 @@ class GitHubIntegration:
         event: Literal["APPROVE", "REQUEST_CHANGES", "COMMENT"],
         body: str | None = None,
     ) -> dict[str, Any]:
-        """
-        Submits a review for a specific pull request in a GitHub repository.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            pr_number (int): The pull request number to review.
-            event (Literal['APPROVE', 'REQUEST_CHANGES', 'COMMENT']): The type of review event.
-            body (str, optional): Required when using REQUEST_CHANGES or COMMENT for the event parameter. Defaults to None.
-        Returns:
-            Dict[str, Any]: The JSON response from the GitHub API containing review information if successful.
-            None: If an error occurs during the review submission process.
-        Error Handling:
-            Logs errors and prints the traceback if the review submission fails, returning None.
-        """
-        logger.info(f"Submitting review for PR {repo_owner}/{repo_name}#{pr_number}")
-
-        # Construct the reviews URL
-        reviews_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/reviews"
-
-        try:
-            response = httpx.post(
-                reviews_url,
-                headers=self._get_headers(),
-                json={"body": body, "event": event},
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"PR #{pr_number} review")
-            review_data = response.json()
-
-            logger.info("Review submitted successfully")
-            return review_data
-
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error submitting review: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Submits a review for a specific pull request."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/reviews"
+        return self._request("POST", url, context=f"PR #{pr_number} review", json={"body": body, "event": event}).json()
 
     @_write
     def update_assignees(
         self, repo_owner: str, repo_name: str, issue_number: int, assignees: list[str]
     ) -> dict[str, Any]:
-        """
-        Updates the assignees for a specific issue or pull request in a GitHub repository.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            issue_number (int): The issue or pull request number to update.
-            assignees (list[str]): A list of usernames to assign to the issue or pull request.
-        Returns:
-            Dict[str, Any]: The updated issue or pull request data as returned by the GitHub API if the update is successful.
-            None: If an error occurs during the update process.
-        Error Handling:
-            Logs an error message and prints the traceback if the request fails or an exception is raised.
-        """
-        logger.info(f"Updating assignees for issue/PR {repo_owner}/{repo_name}#{issue_number}")
-        # Construct the issue URL
-        issue_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{issue_number}"
-        try:
-            # Update the assignees
-            response = httpx.patch(
-                issue_url,
-                headers=self._get_headers(),
-                json={"assignees": assignees},
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"issue/PR #{issue_number} assignees")
-            issue_data = response.json()
-
-            # GitHub silently drops assignees it cannot apply (non-collaborators, unknown users).
-            # Compare requested vs actually assigned and surface any discrepancy.
-            actual_logins = {u["login"] for u in issue_data.get("assignees", [])}
-            requested = set(assignees)
-            missing = requested - actual_logins
-
-            if missing:
-                logger.warning(f"Some assignees were not applied: {missing}")
-                return {
-                    "status": "partial",
-                    "message": f"The following assignees could not be applied (not a collaborator or user does not exist): {sorted(missing)}",
-                    "assignees_requested": sorted(requested),
-                    "assignees_applied": sorted(actual_logins),
-                    "issue": issue_data,
-                }
-
-            logger.info("Assignees updated successfully")
-            return issue_data
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error updating assignees: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Updates the assignees for a specific issue or pull request."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{issue_number}"
+        data = self._request(
+            "PATCH", url, context=f"issue/PR #{issue_number} assignees", json={"assignees": assignees}
+        ).json()
+        actual_logins = {u["login"] for u in data.get("assignees", [])}
+        requested = set(assignees)
+        missing = requested - actual_logins
+        if missing:
+            logger.warning(f"Some assignees were not applied: {missing}")
+            return {
+                "status": "partial",
+                "message": f"The following assignees could not be applied (not a collaborator or user does not exist): {sorted(missing)}",
+                "assignees_requested": sorted(requested),
+                "assignees_applied": sorted(actual_logins),
+                "issue": data,
+            }
+        return data
 
     @_read_only
     def get_latest_sha(self, repo_owner: str, repo_name: str) -> str | None:
-        """
-        Fetches the SHA of the latest commit in the specified GitHub repository.
-        Args:
-            repo_owner (str): The owner of the GitHub repository.
-            repo_name (str): The name of the GitHub repository.
-        Returns:
-            Optional[str]: The SHA string of the latest commit if found, otherwise None.
-        Error Handling:
-            Logs errors and warnings if the request fails, the response is invalid, or no commits are found.
-            Returns None in case of exceptions or if the repository has no commits.
-        """
-        logger.info(f"Fetching latest commit SHA for {repo_owner}/{repo_name}")
-
-        # Construct the commits URL
-        commits_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/commits"
-
-        try:
-            # Fetch the latest commit
-            response = httpx.get(commits_url, headers=self._get_headers(), timeout=TIMEOUT)
-            self._raise_for_status(response, f"commits for {repo_owner}/{repo_name}")
-            commits_data = response.json()
-
-            if commits_data:
-                latest_sha = commits_data[0]["sha"]
-                logger.info(f"Latest commit SHA: {latest_sha}")
-                return latest_sha
-            else:
-                logger.warning("No commits found in the repository")
-                return "No commits found in the repository"
-
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error fetching latest commit SHA: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Fetches the SHA of the latest commit."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/commits"
+        data = self._request("GET", url, context=f"commits for {repo_owner}/{repo_name}").json()
+        if data:
+            return data[0]["sha"]
+        return "No commits found in the repository"
 
     @_write
     def create_tag(self, repo_owner: str, repo_name: str, tag_name: str, message: str) -> dict[str, Any]:
-        """
-        Creates a new tag in the specified GitHub repository.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            tag_name (str): The name of the tag to create.
-            message (str): The message associated with the tag.
-        Returns:
-            Dict[str, Any]: The response data from the GitHub API if the tag is created successfully.
-            None: If an error occurs during the tag creation process.
-        Error Handling:
-            Logs errors and prints the traceback if fetching the latest commit SHA fails or if the GitHub API request fails.
-        """
-        logger.info(f"Creating tag {tag_name} in {repo_owner}/{repo_name}")
-        # Construct the tags URL
-        tags_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs"
-        try:
-            # Fetch the latest commit SHA
-            latest_sha = self.get_latest_sha(repo_owner, repo_name)
-            if not latest_sha:
-                raise ValueError("Failed to fetch the latest commit SHA")
-
-            # Create the tag
-            response = httpx.post(
-                tags_url,
-                headers=self._get_headers(),
-                json={
-                    "ref": f"refs/tags/{tag_name}",
-                    "sha": latest_sha,
-                    "message": message,
-                },
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"create tag {tag_name}")
-            tag_data = response.json()
-
-            logger.info("Tag created successfully")
-            return tag_data
-
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error creating tag: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Creates a new tag."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs"
+        latest_sha = self.get_latest_sha(repo_owner, repo_name)
+        if not latest_sha:
+            raise ValueError("Failed to fetch the latest commit SHA")
+        return self._request(
+            "POST",
+            url,
+            context=f"create tag {tag_name}",
+            json={"ref": f"refs/tags/{tag_name}", "sha": latest_sha, "message": message},
+        ).json()
 
     @_write
     def create_release(
@@ -1028,101 +506,36 @@ class GitHubIntegration:
         generate_release_notes: bool = True,
         make_latest: Literal["true", "false", "legacy"] = "true",
     ) -> dict[str, Any]:
-        """
-        Creates a new release in the specified GitHub repository.
-        Args:
-            repo_owner (str): The owner of the repository.
-            repo_name (str): The name of the repository.
-            tag_name (str): The tag name for the release.
-            release_name (str): The name of the release.
-            body (str): The description or body content of the release.
-            draft (bool, optional): Whether the release is a draft. Defaults to False.
-            prerelease (bool, optional): Whether the release is a prerelease. Defaults to False.
-            generate_release_notes (bool, optional): Whether to generate release notes automatically. Defaults to True.
-            make_latest (Literal['true', 'false', 'legacy'], optional): Whether to mark the release as the latest. Defaults to 'true'.
-        Returns:
-            Dict[str, Any]: The JSON response from the GitHub API containing release information if successful.
-            None: If an error occurs during the release creation process.
-        Error Handling:
-            Logs errors and prints the traceback if the release creation fails, returning None.
-        """
-        logger.info(f"Creating release {release_name} in {repo_owner}/{repo_name}")
-
-        # Construct the releases URL
-        releases_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases"
-
-        try:
-            # Create the release
-            response = httpx.post(
-                releases_url,
-                headers=self._get_headers(),
-                json={
-                    "tag_name": tag_name,
-                    "name": release_name,
-                    "body": body,
-                    "draft": draft,
-                    "prerelease": prerelease,
-                    "generate_release_notes": generate_release_notes,
-                    "make_latest": make_latest,
-                },
-                timeout=TIMEOUT,
-            )
-            self._raise_for_status(response, f"create release {release_name}")
-            release_data = response.json()
-
-            logger.info("Release created successfully")
-            return release_data
-
-        except GitHubAuthError:
-            raise
-        except Exception as e:
-            logger.error(f"Error creating release: {str(e)}")
-            raise ToolError(str(e)) from e
+        """Creates a new release."""
+        url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases"
+        return self._request(
+            "POST",
+            url,
+            context=f"create release {release_name}",
+            json={
+                "tag_name": tag_name,
+                "name": release_name,
+                "body": body,
+                "draft": draft,
+                "prerelease": prerelease,
+                "generate_release_notes": generate_release_notes,
+                "make_latest": make_latest,
+            },
+        ).json()
 
     @_read_only
     def search_user(self, username: str) -> UserSearchResult:
-        """
-        Search for a GitHub user by username using GraphQL API.
-
-        Args:
-            username: GitHub username to search for
-
-        Returns:
-            UserSearchResult: Dictionary containing user profile information including:
-                - login: GitHub username
-                - name: Full name
-                - email: Email address
-                - company: Company name
-                - location: Location
-                - bio: Bio/description
-                - url: Profile URL
-                - avatar_url: Avatar image URL
-                - created_at: Account creation date
-                - updated_at: Last update date
-                - followers: Number of followers
-                - following: Number of users following
-                - public_repos: Total public repositories count
-                - recent_repos: List of recent repositories
-                - organizations: List of organizations the user belongs to
-
-        Raises:
-            GitHubNotFoundError: If the user is not found
-            GitHubAPIError: If the API request fails
-        """
+        """Search for a GitHub user by username using GraphQL API."""
         logger.info(f"Searching for GitHub user: {username}")
-
         try:
             result = self.graphql.execute_query(
                 SEARCH_USER_QUERY,
                 variables={"username": username},
                 token=self._resolve_token(),
             )
-
             user_data = result.get("user")
             if not user_data:
                 raise GitHubNotFoundError(f"User '{username}' not found")
-
-            # Transform GraphQL response to our TypedDict format
             user_info: UserSearchResult = {
                 "login": user_data["login"],
                 "name": user_data.get("name"),
@@ -1156,15 +569,24 @@ class GitHubIntegration:
                     for org in user_data["organizations"]["nodes"]
                 ],
             }
-
             logger.info(f"Successfully found user: {username}")
             return user_info
-
         except GitHubNotFoundError:
             raise
         except Exception as e:
             logger.error(f"Error searching for user {username}: {e}")
             raise GitHubAPIError(f"Failed to search for user: {e}") from e
+
+    def _filtered_contributions(self, collection: dict[str, Any], key: str, org: str, repo: str):
+        for repo_contrib in collection.get(key, []):
+            repo_info = repo_contrib["repository"]
+            owner = repo_info["owner"]["login"]
+            repo_name = repo_info["name"]
+            if org and owner.lower() != org.lower():
+                continue
+            if repo and repo_name.lower() != repo.lower():
+                continue
+            yield repo_contrib, owner, repo_name
 
     @_read_only
     def get_user_activities(
@@ -1176,86 +598,36 @@ class GitHubIntegration:
         until: str = "",
         max_results: int = 50,
     ) -> UserActivityResult:
-        """
-        Get user activities with optional filtering by org, repo, and date range using GraphQL API.
-
-        This method provides a drill-down capability:
-        - username only: Get activities across all repos/orgs
-        - username + org: Filter activities to specific organization
-        - username + org + repo: Drill down to specific repository
-        - + date range: Filter by time period (ISO 8601 format: "2024-01-01T00:00:00Z")
-
-        Args:
-            username: GitHub username to fetch activities for
-            org: Optional organization name to filter by
-            repo: Optional repository name to filter by (requires org)
-            since: Optional start date in ISO 8601 format
-            until: Optional end date in ISO 8601 format
-            max_results: Maximum number of results per category (default: 50)
-
-        Returns:
-            UserActivityResult: Dictionary containing:
-                - username: The GitHub username
-                - date_range: Applied date filter (since/until) if any
-                - total_contributions: Summary counts for commits, PRs, issues, reviews
-                - commits: List of commit contributions
-                - pull_requests: List of PR contributions
-                - issues: List of issue contributions
-                - reviews: List of PR review contributions
-
-        Raises:
-            GitHubNotFoundError: If the user, org, or repo is not found
-            GitHubAPIError: If the API request fails
-        """
+        """Get user activities with optional filtering by org, repo, and date range using GraphQL API."""
         logger.info(f"Fetching user activities for {username} (org={org}, repo={repo}, since={since}, until={until})")
-
         try:
             variables: dict[str, Any] = {"username": username}
             if since:
                 variables["since"] = since
             if until:
                 variables["until"] = until
-
-            # Execute the contributions query
             result = self.graphql.execute_query(
                 USER_CONTRIBUTIONS_QUERY,
                 variables=variables,
                 token=self._resolve_token(),
             )
-
             user_data = result.get("user")
             if not user_data:
                 raise GitHubNotFoundError(f"User '{username}' not found")
-
             collection = user_data.get("contributionsCollection", {})
-
-            # Build date_range info
             date_range = None
             if since or until:
                 date_range = {
                     "since": since if since else collection.get("startedAt", ""),
                     "until": until if until else collection.get("endedAt", ""),
                 }
-
-            # Process contributions and apply org/repo filters
             commits = []
             pull_requests = []
             issues = []
             reviews = []
-
-            # Process commit contributions
-            for repo_contrib in collection.get("commitContributionsByRepository", []):
-                repo_info = repo_contrib["repository"]
-                owner = repo_info["owner"]["login"]
-                repo_name = repo_info["name"]
-
-                # Apply org filter
-                if org and owner.lower() != org.lower():
-                    continue
-                # Apply repo filter
-                if repo and repo_name.lower() != repo.lower():
-                    continue
-
+            for repo_contrib, owner, repo_name in self._filtered_contributions(
+                collection, "commitContributionsByRepository", org, repo
+            ):
                 for contrib in repo_contrib.get("contributions", {}).get("nodes", []):
                     if len(commits) >= max_results:
                         break
@@ -1268,19 +640,9 @@ class GitHubIntegration:
                             "date": contrib.get("occurredAt", ""),
                         }
                     )
-
-            # Process PR contributions
-            for repo_contrib in collection.get("pullRequestContributionsByRepository", []):
-                repo_info = repo_contrib["repository"]
-                owner = repo_info["owner"]["login"]
-                repo_name = repo_info["name"]
-
-                # Apply filters
-                if org and owner.lower() != org.lower():
-                    continue
-                if repo and repo_name.lower() != repo.lower():
-                    continue
-
+            for repo_contrib, owner, repo_name in self._filtered_contributions(
+                collection, "pullRequestContributionsByRepository", org, repo
+            ):
                 for contrib in repo_contrib.get("contributions", {}).get("nodes", []):
                     if len(pull_requests) >= max_results:
                         break
@@ -1297,19 +659,9 @@ class GitHubIntegration:
                             "merged": pr.get("merged", False),
                         }
                     )
-
-            # Process issue contributions
-            for repo_contrib in collection.get("issueContributionsByRepository", []):
-                repo_info = repo_contrib["repository"]
-                owner = repo_info["owner"]["login"]
-                repo_name = repo_info["name"]
-
-                # Apply filters
-                if org and owner.lower() != org.lower():
-                    continue
-                if repo and repo_name.lower() != repo.lower():
-                    continue
-
+            for repo_contrib, owner, repo_name in self._filtered_contributions(
+                collection, "issueContributionsByRepository", org, repo
+            ):
                 for contrib in repo_contrib.get("contributions", {}).get("nodes", []):
                     if len(issues) >= max_results:
                         break
@@ -1325,19 +677,9 @@ class GitHubIntegration:
                             "created": issue["createdAt"],
                         }
                     )
-
-            # Process review contributions
-            for repo_contrib in collection.get("pullRequestReviewContributionsByRepository", []):
-                repo_info = repo_contrib["repository"]
-                owner = repo_info["owner"]["login"]
-                repo_name = repo_info["name"]
-
-                # Apply filters
-                if org and owner.lower() != org.lower():
-                    continue
-                if repo and repo_name.lower() != repo.lower():
-                    continue
-
+            for repo_contrib, owner, repo_name in self._filtered_contributions(
+                collection, "pullRequestReviewContributionsByRepository", org, repo
+            ):
                 for contrib in repo_contrib.get("contributions", {}).get("nodes", []):
                     if len(reviews) >= max_results:
                         break
@@ -1355,7 +697,6 @@ class GitHubIntegration:
                             "date": contrib["occurredAt"],
                         }
                     )
-
             activity_result: UserActivityResult = {
                 "username": username,
                 "date_range": date_range,
@@ -1370,13 +711,11 @@ class GitHubIntegration:
                 "issues": issues,
                 "reviews": reviews,
             }
-
             logger.info(
                 f"Successfully fetched activities: {len(commits)} commits, "
                 f"{len(pull_requests)} PRs, {len(issues)} issues, {len(reviews)} reviews"
             )
             return activity_result
-
         except GitHubNotFoundError:
             raise
         except Exception as e:
@@ -1385,34 +724,17 @@ class GitHubIntegration:
 
     @_read_only
     def get_pr_linked_issues(self, repo_owner: str, repo_name: str, pr_number: int) -> LinkedIssuesResult:
-        """
-
-        Return the issues that will be auto-closed when a pull request is merged.
-
-        Uses `closingIssuesReferences` - authoritative over text-parsing "Closes #N"
-        keywords since it includes issues linked via the GitHub UI.
-
-        Raises
-        ------
-        GitHubNotFoundError
-            If the pull request is not found.
-        GitHubAPIError
-            If the API request fails.
-
-        """
+        """Return the issues that will be auto-closed when a pull request is merged."""
         logger.info(f"Fetching linked issues for PR #{pr_number} in {repo_owner}/{repo_name}")
-
         try:
             result = self.graphql.execute_query(
                 PR_LINKED_ISSUES_QUERY,
                 variables={"owner": repo_owner, "repo": repo_name, "number": pr_number},
                 token=self._resolve_token(),
             )
-
             repo_data = result.get("repository")
             if not repo_data or not repo_data.get("pullRequest"):
                 raise GitHubNotFoundError(f"PR #{pr_number} not found in {repo_owner}/{repo_name}")
-
             nodes = repo_data["pullRequest"]["closingIssuesReferences"]["nodes"]
             linked_issues = [
                 {
@@ -1425,10 +747,8 @@ class GitHubIntegration:
                 }
                 for issue in nodes
             ]
-
             logger.info(f"Found {len(linked_issues)} linked issue(s) for PR #{pr_number}")
             return {"pr_number": pr_number, "linked_issues": linked_issues}
-
         except GitHubNotFoundError:
             raise
         except Exception as e:
@@ -1488,39 +808,21 @@ class GitHubIntegration:
 
     @_read_only
     def get_pr_status_checks(self, repo_owner: str, repo_name: str, pr_number: int) -> StatusChecksResult:
-        """
-
-        Return the CI check runs and commit status for a pull request's HEAD commit.
-
-        Aggregates GitHub Actions check suites and legacy commit status contexts,
-        and derives an overall passing/failing/pending/unknown state.
-
-        Raises
-        ------
-        GitHubNotFoundError
-            If the pull request is not found.
-        GitHubAPIError
-            If the API request fails.
-
-        """
+        """Return the CI check runs and commit status for a pull request's HEAD commit."""
         logger.info(f"Fetching status checks for PR #{pr_number} in {repo_owner}/{repo_name}")
-
         try:
             result = self.graphql.execute_query(
                 PR_STATUS_CHECKS_QUERY,
                 variables={"owner": repo_owner, "repo": repo_name, "number": pr_number},
                 token=self._resolve_token(),
             )
-
             repo_data = result.get("repository")
             if not repo_data or not repo_data.get("pullRequest"):
                 raise GitHubNotFoundError(f"PR #{pr_number} not found in {repo_owner}/{repo_name}")
-
             head_target = (repo_data["pullRequest"].get("headRef") or {}).get("target") or {}
             check_runs = self._flatten_check_runs(head_target)
             commit_statuses = self._extract_commit_statuses(head_target)
             overall = self._derive_overall(check_runs, commit_statuses)
-
             logger.info(f"Status checks for PR #{pr_number}: overall={overall}, runs={len(check_runs)}")
             return {
                 "pr_number": pr_number,
@@ -1528,7 +830,6 @@ class GitHubIntegration:
                 "check_runs": check_runs,
                 "commit_statuses": commit_statuses,
             }
-
         except GitHubNotFoundError:
             raise
         except Exception as e:

--- a/src/mcp_github/graphql_client.py
+++ b/src/mcp_github/graphql_client.py
@@ -25,12 +25,7 @@ from typing import Any
 
 import httpx
 
-from .exceptions import (
-    GitHubAPIError,
-    GitHubAuthError,
-    GitHubNotFoundError,
-    GitHubRateLimitError,
-)
+from .exceptions import GitHubAPIError, GitHubAuthError, GitHubNotFoundError, GitHubRateLimitError
 
 logger = logging.getLogger(__name__)
 
@@ -41,13 +36,7 @@ class GraphQLClient:
     GRAPHQL_URL = "https://api.github.com/graphql"
 
     def __init__(self, token: str, timeout: int = 10):
-        """
-        Initialise the GraphQL client.
-
-        Args:
-            token: GitHub personal access token
-            timeout: Request timeout in seconds
-        """
+        """Initialise the GraphQL client."""
         self.token = token
         self.timeout = timeout
         self.client = httpx.Client(timeout=httpx.Timeout(self.timeout))
@@ -64,27 +53,12 @@ class GraphQLClient:
         variables: dict[str, Any] | None = None,
         token: str | None = None,
     ) -> dict[str, Any]:
-        """
-        Execute a GraphQL query against the GitHub API.
-
-        Args:
-            query: GraphQL query string
-            variables: Query variables dictionary
-
-        Returns:
-            dict: GraphQL response data
-
-        Raises:
-            GitHubAuthError: If authentication fails
-            GitHubRateLimitError: If rate limit is exceeded
-            GitHubNotFoundError: If resource not found
-            GitHubAPIError: For other API errors
-        """
+        """Execute a GraphQL query against the GitHub API."""
         payload: dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = variables
 
-        per_call_headers = {"Authorization": f"Bearer {token}"} if token else {}  # empty string is falsy → no override
+        per_call_headers = {"Authorization": f"Bearer {token}"} if token else {}
 
         try:
             logger.debug(f"Executing GraphQL query with variables: {variables}")
@@ -94,37 +68,31 @@ class GraphQLClient:
                 headers=per_call_headers,
             )
 
-            # Handle HTTP errors
-            if response.status_code == 401:
-                raise GitHubAuthError(
-                    "Authentication failed. Check your GitHub token."
-                    " If using OAuth, the authorization may have been revoked — please re-authenticate.",
-                    response_body=response.json() if response.text else None,
-                )
-            elif response.status_code == 403:
-                # Check if it's a rate limit error
-                reset_header = response.headers.get("X-RateLimit-Reset")
-                raise GitHubRateLimitError(
-                    "GitHub API rate limit exceeded.",
-                    response_body=response.json() if response.text else None,
-                    reset_timestamp=int(reset_header) if reset_header else None,
-                )
-            elif response.status_code == 404:
-                raise GitHubNotFoundError(
-                    "Resource not found",
-                    response_body=response.json() if response.text else None,
-                )
-            elif response.status_code >= 400:
-                raise GitHubAPIError(
-                    f"GraphQL request failed: {response.status_code} - {response.reason_phrase}",
-                    status_code=response.status_code,
-                    response_body=response.json() if response.text else None,
-                )
+            body = response.json() if response.text else None
+            match response.status_code:
+                case 401:
+                    raise GitHubAuthError(
+                        "Authentication failed. Check your GitHub token."
+                        " If using OAuth, the authorization may have been revoked -- please re-authenticate.",
+                        response_body=body,
+                    )
+                case 403:
+                    reset_header = response.headers.get("X-RateLimit-Reset")
+                    raise GitHubRateLimitError(
+                        "GitHub API rate limit exceeded.",
+                        response_body=body,
+                        reset_timestamp=int(reset_header) if reset_header else None,
+                    )
+                case 404:
+                    raise GitHubNotFoundError("Resource not found", response_body=body)
+                case _ if response.status_code >= 400:
+                    raise GitHubAPIError(
+                        f"GraphQL request failed: {response.status_code} - {response.reason_phrase}",
+                        status_code=response.status_code,
+                        response_body=body,
+                    )
 
-            # Parse response
             data = response.json()
-
-            # Handle GraphQL errors in the response body
             if "errors" in data:
                 self._handle_graphql_errors(data["errors"])
 
@@ -134,36 +102,28 @@ class GraphQLClient:
             raise GitHubAPIError(f"GraphQL request failed: {e}") from e
 
     def _handle_graphql_errors(self, errors: list[dict[str, Any]]) -> None:
-        """
-        Handle GraphQL-specific errors from the response.
-
-        Args:
-            errors: List of GraphQL error dictionaries
-
-        Raises:
-            GitHubAPIError: With details from the first relevant error
-        """
+        """Handle GraphQL-specific errors from the response."""
         if not errors:
             return
 
-        # Get the first error for simplicity
         error = errors[0]
-        error_message = error.get("message", "Unknown GraphQL error")
-        error_type = error.get("type", "")
+        msg = error.get("message", "Unknown GraphQL error")
+        err_type = error.get("type", "")
 
-        logger.error(f"GraphQL error: {error_message} (type: {error_type})")
+        logger.error(f"GraphQL error: {msg} (type: {err_type})")
 
-        # Map common GraphQL error patterns to specific exceptions
-        if "NOT_FOUND" in error_type or "not found" in error_message.lower():
-            raise GitHubNotFoundError(error_message)
-        elif "RATE_LIMITED" in error_type:
-            raise GitHubRateLimitError(error_message)
-        elif "FORBIDDEN" in error_type or "UNAUTHORIZED" in error_type:
-            raise GitHubAuthError(
-                error_message + " If using OAuth, the authorization may have been revoked — please re-authenticate."
-            )
+        predicates = [
+            ("NOT_FOUND" in err_type or "not found" in msg.lower(), GitHubNotFoundError),
+            ("RATE_LIMITED" in err_type, GitHubRateLimitError),
+            ("FORBIDDEN" in err_type or "UNAUTHORIZED" in err_type, GitHubAuthError),
+        ]
+        for predicate, exc_cls in predicates:
+            if predicate:
+                hint = (
+                    " If using OAuth, the authorization may have been revoked -- please re-authenticate."
+                    if exc_cls is GitHubAuthError
+                    else ""
+                )
+                raise exc_cls(msg + hint, response_body={"errors": errors})
 
-        raise GitHubAPIError(
-            f"GraphQL error: {error_message}",
-            response_body={"errors": errors},
-        )
+        raise GitHubAPIError(f"GraphQL error: {msg}", response_body={"errors": errors})

--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -45,84 +45,67 @@ PORT = int(getenv("PORT", 8081))
 HOST = getenv("HOST", "localhost")
 MCP_ENABLE_REMOTE = getenv("MCP_ENABLE_REMOTE", False)
 
+_MCP_INSTRUCTIONS = """
+# GitHub PR and Issue Analyser
+
+This server provides tools to analyse GitHub Pull Requests (PRs) and manage GitHub Issues, Tags, and Releases.
+
+## Features
+- Fetch PR diffs, content, linked issues, and CI status
+- Update PR descriptions and post inline review comments
+- Create and update GitHub issues
+- Create tags and releases
+
+## Prerequisites
+1. GitHub integration is preconfigured
+2. Appropriate permissions and GitHub API key is set
+
+## Best Practices
+- Use all tools available for a comprehensive understanding of the PR and issue landscape.
+- Use get_pr_diff (preferred) and get_pr_content for detailed PR analysis
+- Use single dashes instead of em-dashes in PR descriptions and issue bodies
+- Use update_pr_description to keep PRs up-to-date
+- Use create_issue and update_issue for issue management
+- Use create_tag and create_release for release management
+- Always maintain a professional, clear and concise tone
+
+## Skills
+Workflow guidance is available as MCP resources under the skill:// URI scheme:
+- skill://pr-analysis/SKILL.md -- fetch and analyse PR diffs and metadata
+- skill://pr-review/SKILL.md -- post inline comments and submit review decisions
+- skill://pr-management/SKILL.md -- create, update, assign, and merge PRs
+- skill://issue-management/SKILL.md -- create, update, and list issues
+- skill://release-management/SKILL.md -- tag commits and publish releases
+- skill://user-activity/SKILL.md -- look up user profiles and contribution history
+"""
+
 
 class PRIssueAnalyser:
-    """
-    PRIssueAnalyser exposes GitHub PR and issue management as MCP tools.
-
-    Runs in stdio mode (IDE integration) or HTTP mode (remote access via
-    MCP_ENABLE_REMOTE). Tools are auto-registered from public methods on
-    GitHubIntegration via inspect.getmembers().
-    """
+    """PRIssueAnalyser exposes GitHub PR and issue management as MCP tools."""
 
     def __init__(self):
-        """
-        Initialises the main components required for the Issue and PR Analyser.
-        This constructor performs the following actions:
-        - Initialises the GitHub integration and issue processing components.
-        - Sets up the MCP (Multi-Component Platform) server for handling PR analysis, issue creation, and updates.
-        - Registers the necessary MCP tools for further processing.
-        - Logs the successful initialization of the MCP server.
-        """
-
         self.gi = GI()
 
-        # Initialise MCP Server
         def _select_auth():
             if not MCP_ENABLE_REMOTE:
                 return None
             if GITHUB_OAUTH_CLIENT_ID and GITHUB_OAUTH_CLIENT_SECRET and GITHUB_OAUTH_BASE_URL:
-                return self.gi._oauth_verifier  # OAuth2 path
-            return self.gi.verifier  # Default: API key / Bearer token
+                return self.gi._oauth_verifier
+            return self.gi.verifier
 
         self.mcp = FastMCP(
             name="GitHub PR and Issue Analyser",
             auth=_select_auth(),
-            instructions="""
-          # GitHub PR and Issue Analyser
-
-          This server provides tools to analyse GitHub Pull Requests (PRs) and manage GitHub Issues, Tags, and Releases.
-
-          ## Features
-          - Fetch PR diffs, content, linked issues, and CI status
-          - Update PR descriptions and post inline review comments
-          - Create and update GitHub issues
-          - Create tags and releases
-
-          ## Prerequisites
-          1. GitHub integration is preconfigured
-          2. Appropriate permissions and GitHub API key is set
-
-          ## Best Practices
-          - Use all tools available for a comprehensive understanding of the PR and issue landscape.
-          - Use get_pr_diff (preferred) and get_pr_content for detailed PR analysis
-          - Use single dashes instead of em-dashes in PR descriptions and issue bodies
-          - Use update_pr_description to keep PRs up-to-date
-          - Use create_issue and update_issue for issue management
-          - Use create_tag and create_release for release management
-          - Always maintain a professional, clear and concise tone
-
-          ## Skills
-          Workflow guidance is available as MCP resources under the skill:// URI scheme:
-          - skill://pr-analysis/SKILL.md — fetch and analyse PR diffs and metadata
-          - skill://pr-review/SKILL.md — post inline comments and submit review decisions
-          - skill://pr-management/SKILL.md — create, update, assign, and merge PRs
-          - skill://issue-management/SKILL.md — create, update, and list issues
-          - skill://release-management/SKILL.md — tag commits and publish releases
-          - skill://user-activity/SKILL.md — look up user profiles and contribution history
-            """,
+            instructions=_MCP_INSTRUCTIONS,
         )
         self.mcp.add_provider(Choice(name="github_pr_issue_analyser"))
         self.mcp.add_provider(GenerativeUI(tool_name="github_pr_issue_analyser_ui"))
         logger.info("MCP Server initialised")
-
-        self._register_tools()
-
-    def _register_tools(self):
-        self.register_tools(self.gi)
-        self.mcp.add_provider(SkillsDirectoryProvider(Path(__file__).parent / "skills"))
+        self.register_tools()
 
     def register_tools(self, methods: Any = None) -> None:
+        if methods is None:
+            methods = self.gi
         for name in dir(methods):
             if name.startswith("_"):
                 continue
@@ -133,42 +116,28 @@ class PRIssueAnalyser:
                     self.mcp.tool(annotations=annotations)(method)
                 else:
                     self.mcp.add_tool(method)
+        self.mcp.add_provider(SkillsDirectoryProvider(Path(__file__).parent / "skills"))
 
-    def run(self):
-        """
-        Runs the MCP server for GitHub PR analysis.
-        Uses HTTP transport if MCP_ENABLE_REMOTE is set, otherwise uses stdio.
-        """
+    def run(self) -> None:
+        """Runs the MCP server. Uses HTTP if MCP_ENABLE_REMOTE is set, otherwise stdio."""
         try:
             logger.info("Running MCP Server for GitHub PR Analysis.")
             if MCP_ENABLE_REMOTE:
-                self.mcp.run(
-                    transport="http",
-                    host=HOST,
-                    port=PORT,
-                )
+                self.mcp.run(transport="http", host=HOST, port=PORT)
             else:
                 self.mcp.run(transport="stdio")
         except Exception as e:
-            logger.error(f"Fatal Error in MCP Server: {str(e)}")
+            logger.error(f"Fatal Error in MCP Server: {e}")
             traceback.print_exc(file=sys.stderr)
 
 
-def main():
-    """
-    Main function to run the PRIssueAnalyser.
-    This function Initialises the PRIssueAnalyser and starts the MCP server.
-    Returns:
-        None
-    Error Handling:
-        Catches all exceptions, logs the error message, prints the traceback,
-        and terminates the program with exit code 1.
-    """
+def main() -> None:
+    """Main entry point."""
     try:
         review = PRIssueAnalyser()
         review.run()
     except Exception as e:
-        logger.error(f"Error running main analyzer: {str(e)}")
+        logger.error(f"Error running main analyzer: {e}")
         traceback.print_exc()
         sys.exit(1)
 

--- a/src/mcp_github/skills/release-management/SKILL.md
+++ b/src/mcp_github/skills/release-management/SKILL.md
@@ -64,9 +64,46 @@ Format: `vMAJOR.MINOR.PATCH` (e.g. `v2.1.0`)
 
 Pre-release suffixes: `v1.0.0-alpha.1`, `v1.0.0-beta.2`, `v1.0.0-rc.1`
 
+## Release Body Format
+
+The `body` field must follow this structure exactly:
+
+```markdown
+## v{MAJOR}.{MINOR}.{PATCH} -- {YYYY-MM-DD}
+
+### What's Included
+
+- **Feature or fix label** -- brief description
+- **Another change** -- brief description
+
+### ⚠️ Breaking Changes (from v{PREV_MAJOR}.x)
+
+1. **Change title** -- description and migration path
+2. **Another breaking change** -- description
+
+### New Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `VAR_NAME` | Yes/No | What it controls |
+
+### What Changed
+- type(scope): commit message (SHORT_SHA) by @author
+
+**Full Changelog**: https://github.com/{owner}/{repo}/compare/v{PREV}...v{NEW}
+```
+
+Rules:
+- Use `--` (double dash), never em-dashes
+- Date is `YYYY-MM-DD` from the current date
+- Omit `Breaking Changes` and `New Environment Variables` sections when not applicable
+- `What Changed` lists every commit in the release using conventional commit format
+- Short SHA is the first 7 characters of the commit hash
+- `Full Changelog` URL compares the previous tag to the new tag
+
 ## Best Practices
 
-- Always follow semver — never re-use or delete a published tag
+- Always follow semver -- never re-use or delete a published tag
 - Set `draft=True` first to preview the release before publishing
 - Set `generate_release_notes=True` unless you need full manual control over the notes
 - Set `prerelease=True` for alpha/beta/rc versions

--- a/src/mcp_github/skills/user-activity/SKILL.md
+++ b/src/mcp_github/skills/user-activity/SKILL.md
@@ -50,7 +50,8 @@ Returns: `UserActivityResult` — lists of commits, pull requests, issues, and P
 
 ## Date Filtering
 
-- Use ISO 8601 format: `YYYY-MM-DD` (e.g. `2024-01-01`)
+- Accepted formats: `YYYY-MM-DD` (e.g. `2024-01-01`) or full ISO 8601 (`2024-01-01T00:00:00Z`)
+- Date-only values are automatically expanded: `since` becomes `T00:00:00Z`, `until` becomes `T23:59:59Z`
 - `since` is inclusive (contributions on or after this date)
 - `until` is inclusive (contributions on or before this date)
 - Omit both to retrieve the most recent contributions up to `max_results`


### PR DESCRIPTION
## What and why

The codebase has grown considerably since initial deployment. This PR trims it back -- removing verbose docstrings, duplicated try/except blocks, and redundant helper functions without changing any externally visible behaviour.

## Changes

### Source refactoring (`auth`, `exceptions`, `github_integration`, `graphql_client`, `issues_pr_analyser`)

- **Docstrings** -- multi-paragraph docstrings replaced with single-line summaries. The implementation speaks for itself; lengthy argument tables added noise.
- **Decorator consolidation** -- `_read_only`, `_write`, and `_destructive` were three separate functions doing the same thing with different arguments. Replaced with `_annotate()` factory that produces all three.
- **TypedDict syntax** -- changed from PEP 695 `type Foo = TypedDict(...)` aliases (which pyright flagged with `reportInvalidTypeForm`) to standard `class Foo(TypedDict): ...`. Type checking is now clean without ignores.
- **`_request()` helper** -- every tool method duplicated the same pattern: build URL, call `httpx.{verb}`, pass headers and timeout, call `_raise_for_status`, catch `TransportError`, wrap in `ToolError`. Centralised into one method; removed roughly 150 lines of boilerplate.
- **`_parse_redis_db()` inlined** -- single-purpose private helper with one call site; moved inline.
- **`_register_tools()` removed** -- merged into `__init__`; `register_tools()` now defaults to `self.gi` when called without arguments.
- **Bug fix** -- `add_inline_pr_comment` accessed `pr_data["head"]["sha"]` directly. A malformed or unexpected API response would raise a raw `KeyError` bypassing FastMCP's error path. Now guarded with `.get()` and raises `ToolError` with a clear message.

### Release skill (`skills/release-management/SKILL.md`)

Added an explicit **Release Body Format** section with the canonical structure used in published releases -- heading with date, What's Included, optional Breaking Changes and New Environment Variables sections, What Changed commit list, and Full Changelog comparison link. This gives the LLM a concrete template to follow rather than inventing one each time.

## What has not changed

- All public tool signatures are identical
- HTTP behaviour, timeouts, and error types are unchanged
- Auth flows (API key and OAuth2) are unchanged
- Redis and JWT key derivation logic is unchanged