### PR TITLE
fix(tools): update_pr_description returns PRContent shape + GHCR cleanup

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -23,13 +23,20 @@ jobs:
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
     steps:
-      - name: Delete old GHCR images
-        uses: dataaxiom/ghcr-cleanup-action@v1
+      - name: Delete branch-tagged and untagged versions
+        uses: actions/delete-package-versions@v5
         with:
-          exclude-tags: latest
-          keep-n-tagged: 5
-          tag-regex: ^v
-          delete-untagged: true
-          owner: ${{ github.repository_owner }}
-          package: ${{ github.event.repository.name }}
+          package-name: ${{ github.event.repository.name }}
+          package-type: container
+          min-versions-to-keep: 0
+          ignore-versions: ^(latest|v.+)$
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Keep only last 5 release tags
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ github.event.repository.name }}
+          package-type: container
+          min-versions-to-keep: 5
+          ignore-versions: ^latest$
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,35 @@
+name: GHCR Cleanup
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: ghcr-cleanup
+  cancel-in-progress: true
+
+permissions:
+  packages: write
+
+jobs:
+  cleanup:
+    name: cleanup
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
+    steps:
+      - name: Delete old GHCR images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          exclude-tags: latest
+          keep-n-tagged: 5
+          tag-regex: ^v
+          delete-untagged: true
+          owner: ${{ github.repository_owner }}
+          package: ${{ github.event.repository.name }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -302,9 +302,8 @@ class GitHubIntegration:
     ) -> PRContent:
         """Updates the title and description of a specific pull request."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
-        return self._request(
-            "PATCH", url, context=f"PR #{pr_number}", json={"title": new_title, "body": new_description}
-        ).json()
+        self._request("PATCH", url, context=f"PR #{pr_number}", json={"title": new_title, "body": new_description})
+        return self.get_pr_content(repo_owner, repo_name, pr_number)
 
     @_write
     def create_pr(


### PR DESCRIPTION
Two changes on this branch:

**Bug fix** - `update_pr_description` was returning the raw GitHub PATCH response, which uses `body`/`user.login` field names. The declared return type is `PRContent`, which uses `description`/`author`. MCP framework validation was failing because `description` was absent. Fix: after a successful PATCH, delegate to `get_pr_content` to return a properly-shaped response. If the PATCH fails, `_request` raises before `get_pr_content` is ever called.

**GHCR cleanup** - adds `.github/workflows/ghcr-cleanup.yml` to prune old container images after each successful merge to main. Keeps `latest` and the 5 most recent release tags, deletes everything else (branch-tagged versions from PRs and untagged dangling layers). Uses `actions/delete-package-versions@v5` in two steps: first pass removes non-release tags while protecting `latest` and all `v*` tags; second pass caps `v*` tags at 5 most recent.