### PR TITLE
feat(tools): full async conversion + MCP background task protocol for GraphQL tools

### DIFF
--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -206,10 +206,13 @@ class GitHubIntegration:
             self._raise_for_403(response, response_body)
 
         if status == 404:
-            raise GitHubNotFoundError(
-                f"{context}: Resource not found" if context else "Resource not found",
-                response_body=response_body,
-            )
+            msg = f"{context}: Resource not found" if context else "Resource not found"
+            if self._oauth_mode:
+                msg += (
+                    " If this is a private organisation repository, the org admin may need to"
+                    " approve this OAuth App under Org Settings -> Third-party access -> OAuth App access policy."
+                )
+            raise GitHubNotFoundError(msg, response_body=response_body)
 
         if status == 422:
             raise GitHubValidationError("Validation failed. Check your input data.", response_body=response_body)
@@ -225,11 +228,13 @@ class GitHubIntegration:
         """Handle 403 response — distinguishes rate limit from permission error."""
         error_text = response.text.lower()
         if "rate limit" not in error_text and "api rate limit" not in error_text:
-            raise GitHubAPIError(
-                "Permission denied. Check your token permissions.",
-                status_code=403,
-                response_body=response_body,
-            )
+            msg = "Permission denied. Check your token permissions."
+            if self._oauth_mode:
+                msg += (
+                    " If accessing a private organisation repository, the org admin may need to"
+                    " approve this OAuth App under Org Settings -> Third-party access -> OAuth App access policy."
+                )
+            raise GitHubAPIError(msg, status_code=403, response_body=response_body)
         reset_header = response.headers.get("X-RateLimit-Reset")
         raise GitHubRateLimitError(
             "GitHub API rate limit exceeded. Please wait before making more requests.",

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -24,6 +24,7 @@ from os import getenv
 from typing import Annotated, Any, Literal, TypedDict
 
 import httpx
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
@@ -123,9 +124,9 @@ logging.basicConfig(level=logging.WARNING)
 
 
 def _annotate(*, ro: bool = False, destructive: bool = False) -> Any:
-    def deco(fn: Any = None, *, task: bool = False) -> Any:
+    def deco(fn: Any = None, *, task: bool = False, idempotent: bool = False) -> Any:
         def apply(f: Any) -> Any:
-            f._mcp_annotations = ToolAnnotations(readOnlyHint=ro, destructiveHint=destructive)
+            f._mcp_annotations = ToolAnnotations(readOnlyHint=ro, destructiveHint=destructive, idempotentHint=idempotent)
             f._mcp_task = task
             return f
 
@@ -301,7 +302,7 @@ class GitHubIntegration:
             await self._request("POST", review_url, context=f"inline comment on {path}:{line}", json=payload)
         ).json()
 
-    @_write
+    @_write(idempotent=True)
     async def update_pr_description(
         self,
         repo_owner: str,
@@ -398,7 +399,7 @@ class GitHubIntegration:
             )
         ).json()
 
-    @_destructive
+    @_write
     async def merge_pr(
         self,
         repo_owner: str,
@@ -407,8 +408,16 @@ class GitHubIntegration:
         commit_title: str | None = None,
         commit_message: str | None = None,
         merge_method: Literal["merge", "squash", "rebase"] = "squash",
+        ctx: Context | None = None,
     ) -> dict[str, Any]:
         """Merges a specific pull request."""
+        if ctx:
+            confirmation = await ctx.elicit(
+                f"About to merge PR #{pr_number} in {repo_owner}/{repo_name} via '{merge_method}'. Confirm?",
+                response_type=None,
+            )
+            if confirmation.action != "accept":
+                raise GitHubValidationError("Merge cancelled.")
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/merge"
         payload: dict[str, Any] = {"merge_method": merge_method}
         if commit_title is not None:
@@ -423,7 +432,7 @@ class GitHubIntegration:
             logger.error(f"Error merging PR: {detail}")
             raise ToolError(detail) from e
 
-    @_write
+    @_write(idempotent=True)
     async def update_pr_branch(
         self,
         repo_owner: str,
@@ -438,7 +447,7 @@ class GitHubIntegration:
             payload["expected_head_sha"] = expected_head_sha
         return (await self._request("PUT", url, context=f"PR #{pr_number} update branch", json=payload)).json()
 
-    @_write
+    @_write(idempotent=True)
     async def update_issue(
         self,
         repo_owner: str,
@@ -475,7 +484,7 @@ class GitHubIntegration:
             await self._request("POST", url, context=f"PR #{pr_number} review", json={"body": body, "event": event})
         ).json()
 
-    @_write
+    @_write(idempotent=True)
     async def update_assignees(
         self, repo_owner: str, repo_name: str, issue_number: int, assignees: list[str]
     ) -> dict[str, Any]:
@@ -632,6 +641,7 @@ class GitHubIntegration:
         since: str = "",
         until: str = "",
         max_results: int = 50,
+        ctx: Context | None = None,
     ) -> UserActivityResult:
         """Get user activities with optional filtering by org, repo, and date range using GraphQL API. since/until accept YYYY-MM-DD or full ISO 8601 (YYYY-MM-DDTHH:MM:SSZ)."""
         logger.info(f"Fetching user activities for {username} (org={org}, repo={repo}, since={since}, until={until})")
@@ -661,6 +671,9 @@ class GitHubIntegration:
             pull_requests = []
             issues = []
             reviews = []
+            if ctx:
+                await ctx.report_progress(progress=0, total=4)
+                await ctx.info("Fetching commits...")
             for repo_contrib, owner, repo_name in self._filtered_contributions(
                 collection, "commitContributionsByRepository", org, repo
             ):
@@ -676,6 +689,9 @@ class GitHubIntegration:
                             "date": contrib.get("occurredAt", ""),
                         }
                     )
+            if ctx:
+                await ctx.report_progress(progress=1, total=4)
+                await ctx.info("Fetching pull requests...")
             for repo_contrib, owner, repo_name in self._filtered_contributions(
                 collection, "pullRequestContributionsByRepository", org, repo
             ):
@@ -695,6 +711,9 @@ class GitHubIntegration:
                             "merged": pr.get("merged", False),
                         }
                     )
+            if ctx:
+                await ctx.report_progress(progress=2, total=4)
+                await ctx.info("Fetching issues...")
             for repo_contrib, owner, repo_name in self._filtered_contributions(
                 collection, "issueContributionsByRepository", org, repo
             ):
@@ -713,6 +732,9 @@ class GitHubIntegration:
                             "created": issue["createdAt"],
                         }
                     )
+            if ctx:
+                await ctx.report_progress(progress=3, total=4)
+                await ctx.info("Fetching reviews...")
             for repo_contrib, owner, repo_name in self._filtered_contributions(
                 collection, "pullRequestReviewContributionsByRepository", org, repo
             ):
@@ -733,6 +755,8 @@ class GitHubIntegration:
                             "date": contrib["occurredAt"],
                         }
                     )
+            if ctx:
+                await ctx.report_progress(progress=4, total=4)
             activity_result: UserActivityResult = {
                 "username": username,
                 "date_range": date_range,
@@ -844,7 +868,13 @@ class GitHubIntegration:
         return "passing"
 
     @_read_only(task=True)
-    async def get_pr_status_checks(self, repo_owner: str, repo_name: str, pr_number: int) -> StatusChecksResult:
+    async def get_pr_status_checks(
+        self,
+        repo_owner: str,
+        repo_name: str,
+        pr_number: int,
+        ctx: Context | None = None,
+    ) -> StatusChecksResult:
         """Return the CI check runs and commit status for a pull request's HEAD commit."""
         logger.info(f"Fetching status checks for PR #{pr_number} in {repo_owner}/{repo_name}")
         try:
@@ -858,8 +888,14 @@ class GitHubIntegration:
             if not repo_data or not repo_data.get("pullRequest"):
                 raise GitHubNotFoundError(f"PR #{pr_number} not found in {repo_owner}/{repo_name}")
             head_target = (repo_data["pullRequest"].get("headRef") or {}).get("target") or {}
+            check_suites = head_target.get("checkSuites", {}).get("nodes", [])
             check_runs = self._flatten_check_runs(head_target)
             commit_statuses = self._extract_commit_statuses(head_target)
+            if ctx:
+                await ctx.info(
+                    f"Found {len(check_suites)} check suites, "
+                    f"{len(check_runs)} runs, {len(commit_statuses)} legacy statuses"
+                )
             overall = self._derive_overall(check_runs, commit_statuses)
             logger.info(f"Status checks for PR #{pr_number}: overall={overall}, runs={len(check_runs)}")
             return {

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from os import getenv
 from typing import Annotated, Any, Literal, TypedDict
@@ -122,9 +123,15 @@ logging.basicConfig(level=logging.WARNING)
 
 
 def _annotate(*, ro: bool = False, destructive: bool = False) -> Any:
-    def deco(fn: Any) -> Any:
-        fn._mcp_annotations = ToolAnnotations(readOnlyHint=ro, destructiveHint=destructive)
-        return fn
+    def deco(fn: Any = None, *, task: bool = False) -> Any:
+        def apply(f: Any) -> Any:
+            f._mcp_annotations = ToolAnnotations(readOnlyHint=ro, destructiveHint=destructive)
+            f._mcp_task = task
+            return f
+
+        if fn is not None:
+            return apply(fn)
+        return apply
 
     return deco
 
@@ -529,12 +536,13 @@ class GitHubIntegration:
             },
         ).json()
 
-    @_read_only
-    def search_user(self, username: str) -> UserSearchResult:
+    @_read_only(task=True)
+    async def search_user(self, username: str) -> UserSearchResult:
         """Search for a GitHub user by username using GraphQL API."""
         logger.info(f"Searching for GitHub user: {username}")
         try:
-            result = self.graphql.execute_query(
+            result = await asyncio.to_thread(
+                self.graphql.execute_query,
                 SEARCH_USER_QUERY,
                 variables={"username": username},
                 token=self._resolve_token(),
@@ -594,8 +602,8 @@ class GitHubIntegration:
                 continue
             yield repo_contrib, owner, repo_name
 
-    @_read_only
-    def get_user_activities(
+    @_read_only(task=True)
+    async def get_user_activities(
         self,
         username: str,
         org: str = "",
@@ -612,7 +620,8 @@ class GitHubIntegration:
                 variables["since"] = since + "T00:00:00Z" if len(since) == 10 else since
             if until:
                 variables["until"] = until + "T23:59:59Z" if len(until) == 10 else until
-            result = self.graphql.execute_query(
+            result = await asyncio.to_thread(
+                self.graphql.execute_query,
                 USER_CONTRIBUTIONS_QUERY,
                 variables=variables,
                 token=self._resolve_token(),

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -160,7 +160,21 @@ class GitHubIntegration:
         # GraphQL client: token overridden per-call in OAuth2 mode via _resolve_token()
         self.graphql = GraphQLClient(self.github_token or "", timeout=TIMEOUT)
 
+        self._http = httpx.AsyncClient(timeout=TIMEOUT)
+
         logger.info("GitHub Integration Initialised")
+
+    async def aclose(self) -> None:
+        """Close the shared HTTP client."""
+        await self._http.aclose()
+
+    async def __aenter__(self) -> GitHubIntegration:
+        """Enter async context manager."""
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        """Exit async context manager and close HTTP client."""
+        await self.aclose()
 
     @property
     def _oauth_verifier(self):
@@ -244,8 +258,7 @@ class GitHubIntegration:
         ctx = context or url
         logger.info(f"{method.upper()} {ctx}")
         try:
-            async with httpx.AsyncClient() as client:
-                response = await client.request(method, url, headers=self._get_headers(), timeout=TIMEOUT, **kwargs)
+            response = await self._http.request(method, url, headers=self._get_headers(), **kwargs)
             self._raise_for_status(response, context)
             logger.info(f"Success {method.upper()} {ctx}")
             return response
@@ -424,13 +437,7 @@ class GitHubIntegration:
             payload["commit_title"] = commit_title
         if commit_message is not None:
             payload["commit_message"] = commit_message
-        try:
-            return (await self._request("PUT", url, context=f"PR #{pr_number} merge", json=payload)).json()
-        except GitHubAPIError as e:
-            github_msg = (e.response_body or {}).get("message", "") if e.response_body else ""
-            detail = github_msg or str(e)
-            logger.error(f"Error merging PR: {detail}")
-            raise ToolError(detail) from e
+        return (await self._request("PUT", url, context=f"PR #{pr_number} merge", json=payload)).json()
 
     @_write(idempotent=True)
     async def update_pr_branch(
@@ -651,6 +658,8 @@ class GitHubIntegration:
                 variables["since"] = since + "T00:00:00Z" if len(since) == 10 else since
             if until:
                 variables["until"] = until + "T23:59:59Z" if len(until) == 10 else until
+            if ctx:
+                await ctx.info(f"Querying GitHub contributions for {username}...")
             result = await asyncio.to_thread(
                 self.graphql.execute_query,
                 USER_CONTRIBUTIONS_QUERY,
@@ -888,12 +897,12 @@ class GitHubIntegration:
             if not repo_data or not repo_data.get("pullRequest"):
                 raise GitHubNotFoundError(f"PR #{pr_number} not found in {repo_owner}/{repo_name}")
             head_target = (repo_data["pullRequest"].get("headRef") or {}).get("target") or {}
-            check_suites = head_target.get("checkSuites", {}).get("nodes", [])
             check_runs = self._flatten_check_runs(head_target)
             commit_statuses = self._extract_commit_statuses(head_target)
             if ctx:
+                n_suites = len(head_target.get("checkSuites", {}).get("nodes", []))
                 await ctx.info(
-                    f"Found {len(check_suites)} check suites, "
+                    f"Found {n_suites} check suites, "
                     f"{len(check_runs)} runs, {len(commit_statuses)} legacy statuses"
                 )
             overall = self._derive_overall(check_runs, commit_statuses)

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -238,12 +238,13 @@ class GitHubIntegration:
         }
         return headers
 
-    def _request(self, method: str, url: str, *, context: str = "", **kwargs: Any) -> httpx.Response:
+    async def _request(self, method: str, url: str, *, context: str = "", **kwargs: Any) -> httpx.Response:
         """Make an HTTP request and handle errors."""
         ctx = context or url
         logger.info(f"{method.upper()} {ctx}")
         try:
-            response = httpx.request(method, url, headers=self._get_headers(), timeout=TIMEOUT, **kwargs)
+            async with httpx.AsyncClient() as client:
+                response = await client.request(method, url, headers=self._get_headers(), timeout=TIMEOUT, **kwargs)
             self._raise_for_status(response, context)
             logger.info(f"Success {method.upper()} {ctx}")
             return response
@@ -253,16 +254,16 @@ class GitHubIntegration:
             raise ToolError(str(e)) from e
 
     @_read_only
-    def get_pr_diff(self, repo_owner: str, repo_name: str, pr_number: int) -> str:
+    async def get_pr_diff(self, repo_owner: str, repo_name: str, pr_number: int) -> str:
         """Fetches the diff/patch of a specific pull request."""
         url = f"https://patch-diff.githubusercontent.com/raw/{repo_owner}/{repo_name}/pull/{pr_number}.patch"
-        return self._request("GET", url, context=f"PR #{pr_number} diff").text
+        return (await self._request("GET", url, context=f"PR #{pr_number} diff")).text
 
     @_read_only
-    def get_pr_content(self, repo_owner: str, repo_name: str, pr_number: int) -> PRContent:
+    async def get_pr_content(self, repo_owner: str, repo_name: str, pr_number: int) -> PRContent:
         """Fetches the content/details of a specific pull request."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
-        data = self._request("GET", url, context=f"PR #{pr_number}").json()
+        data = (await self._request("GET", url, context=f"PR #{pr_number}")).json()
         return {
             "title": data["title"],
             "description": data["body"],
@@ -273,13 +274,13 @@ class GitHubIntegration:
         }
 
     @_write
-    def add_pr_comments(self, repo_owner: str, repo_name: str, pr_number: int, comment: str) -> CommentData:
+    async def add_pr_comments(self, repo_owner: str, repo_name: str, pr_number: int, comment: str) -> CommentData:
         """Adds a comment to a specific pull request."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments"
-        return self._request("POST", url, context=f"PR #{pr_number} comment", json={"body": comment}).json()
+        return (await self._request("POST", url, context=f"PR #{pr_number} comment", json={"body": comment})).json()
 
     @_write
-    def add_inline_pr_comment(
+    async def add_inline_pr_comment(
         self,
         repo_owner: str,
         repo_name: str,
@@ -290,16 +291,18 @@ class GitHubIntegration:
     ) -> CommentData:
         """Adds an inline review comment to a specific line in a file within a PR."""
         pr_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
-        pr_data = self._request("GET", pr_url, context=f"PR #{pr_number}").json()
+        pr_data = (await self._request("GET", pr_url, context=f"PR #{pr_number}")).json()
         commit_id = pr_data.get("head", {}).get("sha")
         if not commit_id:
             raise ToolError(f"Could not retrieve head SHA for PR #{pr_number}")
         review_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments"
         payload = {"body": comment_body, "commit_id": commit_id, "path": path, "line": line, "side": "RIGHT"}
-        return self._request("POST", review_url, context=f"inline comment on {path}:{line}", json=payload).json()
+        return (
+            await self._request("POST", review_url, context=f"inline comment on {path}:{line}", json=payload)
+        ).json()
 
     @_write
-    def update_pr_description(
+    async def update_pr_description(
         self,
         repo_owner: str,
         repo_name: str,
@@ -309,11 +312,13 @@ class GitHubIntegration:
     ) -> PRContent:
         """Updates the title and description of a specific pull request."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}"
-        self._request("PATCH", url, context=f"PR #{pr_number}", json={"title": new_title, "body": new_description})
-        return self.get_pr_content(repo_owner, repo_name, pr_number)
+        await self._request(
+            "PATCH", url, context=f"PR #{pr_number}", json={"title": new_title, "body": new_description}
+        )
+        return await self.get_pr_content(repo_owner, repo_name, pr_number)
 
     @_write
-    def create_pr(
+    async def create_pr(
         self,
         repo_owner: str,
         repo_name: str,
@@ -325,11 +330,13 @@ class GitHubIntegration:
     ) -> dict[str, Any]:
         """Creates a new pull request."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls"
-        data = self._request(
-            "POST",
-            url,
-            context=f"create PR {head} -> {base}",
-            json={"title": title, "body": body, "head": head, "base": base, "draft": draft},
+        data = (
+            await self._request(
+                "POST",
+                url,
+                context=f"create PR {head} -> {base}",
+                json={"title": title, "body": body, "head": head, "base": base, "draft": draft},
+            )
         ).json()
         return {
             "pr_url": data.get("html_url"),
@@ -339,7 +346,7 @@ class GitHubIntegration:
         }
 
     @_read_only
-    def list_open_issues_prs(
+    async def list_open_issues_prs(
         self,
         repo_owner: str,
         repo_name: str = "",
@@ -356,7 +363,7 @@ class GitHubIntegration:
         else:
             search_target = repo_owner
         url = f"https://api.github.com/search/issues?q=is:{issue}+is:open+{filtering}:{search_target}&per_page={per_page}&page={page}"
-        data = self._request("GET", url, context=f"list open {issue}s for {search_target}").json()
+        data = (await self._request("GET", url, context=f"list open {issue}s for {search_target}")).json()
         return {
             "total": data["total_count"],
             f"open_{issue}s": [
@@ -376,19 +383,23 @@ class GitHubIntegration:
         }
 
     @_write
-    def create_issue(self, repo_owner: str, repo_name: str, title: str, body: str, labels: list[str]) -> IssueData:
+    async def create_issue(
+        self, repo_owner: str, repo_name: str, title: str, body: str, labels: list[str]
+    ) -> IssueData:
         """Creates a new issue."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues"
         issue_labels = ["mcp"] if not labels else labels + ["mcp"]
-        return self._request(
-            "POST",
-            url,
-            context=f"create issue in {repo_owner}/{repo_name}",
-            json={"title": title, "body": body, "labels": issue_labels},
+        return (
+            await self._request(
+                "POST",
+                url,
+                context=f"create issue in {repo_owner}/{repo_name}",
+                json={"title": title, "body": body, "labels": issue_labels},
+            )
         ).json()
 
     @_destructive
-    def merge_pr(
+    async def merge_pr(
         self,
         repo_owner: str,
         repo_name: str,
@@ -405,7 +416,7 @@ class GitHubIntegration:
         if commit_message is not None:
             payload["commit_message"] = commit_message
         try:
-            return self._request("PUT", url, context=f"PR #{pr_number} merge", json=payload).json()
+            return (await self._request("PUT", url, context=f"PR #{pr_number} merge", json=payload)).json()
         except GitHubAPIError as e:
             github_msg = (e.response_body or {}).get("message", "") if e.response_body else ""
             detail = github_msg or str(e)
@@ -413,7 +424,7 @@ class GitHubIntegration:
             raise ToolError(detail) from e
 
     @_write
-    def update_pr_branch(
+    async def update_pr_branch(
         self,
         repo_owner: str,
         repo_name: str,
@@ -425,10 +436,10 @@ class GitHubIntegration:
         payload: dict[str, Any] = {}
         if expected_head_sha is not None:
             payload["expected_head_sha"] = expected_head_sha
-        return self._request("PUT", url, context=f"PR #{pr_number} update branch", json=payload).json()
+        return (await self._request("PUT", url, context=f"PR #{pr_number} update branch", json=payload)).json()
 
     @_write
-    def update_issue(
+    async def update_issue(
         self,
         repo_owner: str,
         repo_name: str,
@@ -440,15 +451,17 @@ class GitHubIntegration:
     ) -> IssueData:
         """Updates an existing issue."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{issue_number}"
-        return self._request(
-            "PATCH",
-            url,
-            context=f"issue #{issue_number}",
-            json={"title": title, "body": body, "labels": labels, "state": state},
+        return (
+            await self._request(
+                "PATCH",
+                url,
+                context=f"issue #{issue_number}",
+                json={"title": title, "body": body, "labels": labels, "state": state},
+            )
         ).json()
 
     @_write
-    def update_reviews(
+    async def update_reviews(
         self,
         repo_owner: str,
         repo_name: str,
@@ -458,16 +471,20 @@ class GitHubIntegration:
     ) -> dict[str, Any]:
         """Submits a review for a specific pull request."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/reviews"
-        return self._request("POST", url, context=f"PR #{pr_number} review", json={"body": body, "event": event}).json()
+        return (
+            await self._request("POST", url, context=f"PR #{pr_number} review", json={"body": body, "event": event})
+        ).json()
 
     @_write
-    def update_assignees(
+    async def update_assignees(
         self, repo_owner: str, repo_name: str, issue_number: int, assignees: list[str]
     ) -> dict[str, Any]:
         """Updates the assignees for a specific issue or pull request."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/issues/{issue_number}"
-        data = self._request(
-            "PATCH", url, context=f"issue/PR #{issue_number} assignees", json={"assignees": assignees}
+        data = (
+            await self._request(
+                "PATCH", url, context=f"issue/PR #{issue_number} assignees", json={"assignees": assignees}
+            )
         ).json()
         actual_logins = {u["login"] for u in data.get("assignees", [])}
         requested = set(assignees)
@@ -484,30 +501,32 @@ class GitHubIntegration:
         return data
 
     @_read_only
-    def get_latest_sha(self, repo_owner: str, repo_name: str) -> str | None:
+    async def get_latest_sha(self, repo_owner: str, repo_name: str) -> str | None:
         """Fetches the SHA of the latest commit."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/commits"
-        data = self._request("GET", url, context=f"commits for {repo_owner}/{repo_name}").json()
+        data = (await self._request("GET", url, context=f"commits for {repo_owner}/{repo_name}")).json()
         if data:
             return data[0]["sha"]
         return "No commits found in the repository"
 
     @_write
-    def create_tag(self, repo_owner: str, repo_name: str, tag_name: str, message: str) -> dict[str, Any]:
+    async def create_tag(self, repo_owner: str, repo_name: str, tag_name: str, message: str) -> dict[str, Any]:
         """Creates a new tag."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs"
-        latest_sha = self.get_latest_sha(repo_owner, repo_name)
+        latest_sha = await self.get_latest_sha(repo_owner, repo_name)
         if not latest_sha:
             raise ValueError("Failed to fetch the latest commit SHA")
-        return self._request(
-            "POST",
-            url,
-            context=f"create tag {tag_name}",
-            json={"ref": f"refs/tags/{tag_name}", "sha": latest_sha, "message": message},
+        return (
+            await self._request(
+                "POST",
+                url,
+                context=f"create tag {tag_name}",
+                json={"ref": f"refs/tags/{tag_name}", "sha": latest_sha, "message": message},
+            )
         ).json()
 
     @_write
-    def create_release(
+    async def create_release(
         self,
         repo_owner: str,
         repo_name: str,
@@ -521,19 +540,21 @@ class GitHubIntegration:
     ) -> dict[str, Any]:
         """Creates a new release."""
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/releases"
-        return self._request(
-            "POST",
-            url,
-            context=f"create release {release_name}",
-            json={
-                "tag_name": tag_name,
-                "name": release_name,
-                "body": body,
-                "draft": draft,
-                "prerelease": prerelease,
-                "generate_release_notes": generate_release_notes,
-                "make_latest": make_latest,
-            },
+        return (
+            await self._request(
+                "POST",
+                url,
+                context=f"create release {release_name}",
+                json={
+                    "tag_name": tag_name,
+                    "name": release_name,
+                    "body": body,
+                    "draft": draft,
+                    "prerelease": prerelease,
+                    "generate_release_notes": generate_release_notes,
+                    "make_latest": make_latest,
+                },
+            )
         ).json()
 
     @_read_only(task=True)
@@ -737,12 +758,13 @@ class GitHubIntegration:
             logger.error(f"Error fetching user activities for {username}: {e}")
             raise GitHubAPIError(f"Failed to fetch user activities: {e}") from e
 
-    @_read_only
-    def get_pr_linked_issues(self, repo_owner: str, repo_name: str, pr_number: int) -> LinkedIssuesResult:
+    @_read_only(task=True)
+    async def get_pr_linked_issues(self, repo_owner: str, repo_name: str, pr_number: int) -> LinkedIssuesResult:
         """Return the issues that will be auto-closed when a pull request is merged."""
         logger.info(f"Fetching linked issues for PR #{pr_number} in {repo_owner}/{repo_name}")
         try:
-            result = self.graphql.execute_query(
+            result = await asyncio.to_thread(
+                self.graphql.execute_query,
                 PR_LINKED_ISSUES_QUERY,
                 variables={"owner": repo_owner, "repo": repo_name, "number": pr_number},
                 token=self._resolve_token(),
@@ -821,12 +843,13 @@ class GitHubIntegration:
             return "pending"
         return "passing"
 
-    @_read_only
-    def get_pr_status_checks(self, repo_owner: str, repo_name: str, pr_number: int) -> StatusChecksResult:
+    @_read_only(task=True)
+    async def get_pr_status_checks(self, repo_owner: str, repo_name: str, pr_number: int) -> StatusChecksResult:
         """Return the CI check runs and commit status for a pull request's HEAD commit."""
         logger.info(f"Fetching status checks for PR #{pr_number} in {repo_owner}/{repo_name}")
         try:
-            result = self.graphql.execute_query(
+            result = await asyncio.to_thread(
+                self.graphql.execute_query,
                 PR_STATUS_CHECKS_QUERY,
                 variables={"owner": repo_owner, "repo": repo_name, "number": pr_number},
                 token=self._resolve_token(),

--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -113,7 +113,8 @@ class PRIssueAnalyser:
             if inspect.isroutine(method):
                 annotations = getattr(method, "_mcp_annotations", None)
                 if annotations is not None:
-                    self.mcp.tool(annotations=annotations)(method)
+                    task = getattr(method, "_mcp_task", False)
+                    self.mcp.tool(annotations=annotations, task=task)(method)
                 else:
                     self.mcp.add_tool(method)
         self.mcp.add_provider(SkillsDirectoryProvider(Path(__file__).parent / "skills"))

--- a/tests/test_github_integration.py
+++ b/tests/test_github_integration.py
@@ -1,0 +1,369 @@
+"""Tests for GitHubIntegration — annotations, async HTTP, Context injection."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import httpx
+import pytest
+
+from fastmcp.exceptions import ToolError
+from mcp_github.exceptions import GitHubValidationError
+from mcp_github.github_integration import (
+    GitHubIntegration,
+    _destructive,
+    _read_only,
+    _write,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code: int = 200, json_data: dict | None = None, text: str = "") -> MagicMock:
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status_code
+    r.is_success = status_code < 400
+    r.json.return_value = json_data if json_data is not None else {}
+    r.text = text
+    r.reason_phrase = "OK"
+    r.headers = {}
+    return r
+
+
+def _mock_ctx() -> AsyncMock:
+    ctx = AsyncMock()
+    ctx.info = AsyncMock()
+    ctx.report_progress = AsyncMock()
+    ctx.elicit = AsyncMock()
+    return ctx
+
+
+_EMPTY_CONTRIBUTIONS = {
+    "user": {
+        "contributionsCollection": {
+            "commitContributionsByRepository": [],
+            "pullRequestContributionsByRepository": [],
+            "issueContributionsByRepository": [],
+            "pullRequestReviewContributionsByRepository": [],
+            "totalCommitContributions": 0,
+            "totalPullRequestContributions": 0,
+            "totalIssueContributions": 0,
+            "totalPullRequestReviewContributions": 0,
+        }
+    }
+}
+
+_EMPTY_STATUS_CHECKS = {
+    "repository": {
+        "pullRequest": {
+            "headRef": {
+                "target": {
+                    "checkSuites": {"nodes": [{"checkRuns": {"nodes": []}}]},
+                    "status": None,
+                }
+            }
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gi() -> GitHubIntegration:
+    with patch("mcp_github.github_integration.GITHUB_TOKEN", "test-token"):
+        instance = GitHubIntegration()
+    instance._http = AsyncMock()
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Annotation semantics
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotations:
+    def test_read_only_hints(self):
+        def fn(): ...
+
+        _read_only(fn)
+        ann = fn._mcp_annotations
+        assert ann.readOnlyHint is True
+        assert ann.destructiveHint is False
+        assert ann.idempotentHint is False
+        assert fn._mcp_task is False
+
+    def test_read_only_with_task(self):
+        def fn(): ...
+
+        _read_only(task=True)(fn)
+        ann = fn._mcp_annotations
+        assert ann.readOnlyHint is True
+        assert fn._mcp_task is True
+
+    def test_write_hints(self):
+        def fn(): ...
+
+        _write(fn)
+        ann = fn._mcp_annotations
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is False
+        assert ann.idempotentHint is False
+        assert fn._mcp_task is False
+
+    def test_write_idempotent(self):
+        def fn(): ...
+
+        _write(idempotent=True)(fn)
+        ann = fn._mcp_annotations
+        assert ann.readOnlyHint is False
+        assert ann.destructiveHint is False
+        assert ann.idempotentHint is True
+
+    def test_destructive_hints(self):
+        def fn(): ...
+
+        _destructive(fn)
+        ann = fn._mcp_annotations
+        assert ann.destructiveHint is True
+        assert ann.readOnlyHint is False
+
+    def test_idempotent_tools_annotated_correctly(self, gi: GitHubIntegration):
+        for name in ("update_pr_description", "update_pr_branch", "update_issue", "update_assignees"):
+            method = getattr(gi, name)
+            ann = method._mcp_annotations
+            assert ann.idempotentHint is True, f"{name} should have idempotentHint=True"
+            assert ann.destructiveHint is False, f"{name} should not be destructive"
+
+    def test_merge_pr_is_write_not_destructive(self, gi: GitHubIntegration):
+        ann = gi.merge_pr._mcp_annotations
+        assert ann.destructiveHint is False
+        assert ann.readOnlyHint is False
+
+
+# ---------------------------------------------------------------------------
+# Connection pooling — single shared client
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionPooling:
+    @pytest.mark.anyio
+    async def test_shared_client_not_recreated_per_request(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(return_value=_mock_response(json_data=[{"sha": "abc"}]))
+        with patch("httpx.AsyncClient") as mock_cls:
+            await gi.get_latest_sha("owner", "repo")
+            await gi.get_latest_sha("owner", "repo")
+        mock_cls.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_same_client_instance_across_calls(self, gi: GitHubIntegration):
+        client_before = gi._http
+        gi._http.request = AsyncMock(return_value=_mock_response(json_data=[{"sha": "abc"}]))
+        await gi.get_latest_sha("owner", "repo")
+        assert gi._http is client_before
+
+
+# ---------------------------------------------------------------------------
+# aclose / async context manager
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.anyio
+    async def test_aclose_delegates_to_http_client(self, gi: GitHubIntegration):
+        gi._http.aclose = AsyncMock()
+        await gi.aclose()
+        gi._http.aclose.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_async_context_manager_closes_on_exit(self, gi: GitHubIntegration):
+        gi._http.aclose = AsyncMock()
+        async with gi as g:
+            assert g is gi
+        gi._http.aclose.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_context_manager_closes_on_exception(self, gi: GitHubIntegration):
+        gi._http.aclose = AsyncMock()
+        with pytest.raises(RuntimeError):
+            async with gi:
+                raise RuntimeError("boom")
+        gi._http.aclose.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# merge_pr — elicitation and dead-except removal
+# ---------------------------------------------------------------------------
+
+
+class TestMergePr:
+    @pytest.mark.anyio
+    async def test_merges_without_ctx(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(return_value=_mock_response(json_data={"merged": True}))
+        result = await gi.merge_pr("owner", "repo", 42)
+        assert result == {"merged": True}
+
+    @pytest.mark.anyio
+    async def test_elicitation_accepted_proceeds_with_merge(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(return_value=_mock_response(json_data={"merged": True}))
+        ctx = _mock_ctx()
+        ctx.elicit.return_value = MagicMock(action="accept")
+        result = await gi.merge_pr("owner", "repo", 42, ctx=ctx)
+        ctx.elicit.assert_called_once()
+        assert "squash" in ctx.elicit.call_args[0][0]
+        assert result == {"merged": True}
+
+    @pytest.mark.anyio
+    async def test_elicitation_declined_raises_validation_error(self, gi: GitHubIntegration):
+        ctx = _mock_ctx()
+        ctx.elicit.return_value = MagicMock(action="decline")
+        with pytest.raises(GitHubValidationError, match="Merge cancelled"):
+            await gi.merge_pr("owner", "repo", 42, ctx=ctx)
+        gi._http.request.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_elicitation_cancel_raises_validation_error(self, gi: GitHubIntegration):
+        ctx = _mock_ctx()
+        ctx.elicit.return_value = MagicMock(action="cancel")
+        with pytest.raises(GitHubValidationError):
+            await gi.merge_pr("owner", "repo", 42, ctx=ctx)
+        gi._http.request.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_http_error_propagates_as_tool_error(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(
+            return_value=_mock_response(status_code=405, json_data={"message": "Not mergeable"})
+        )
+        with pytest.raises(ToolError):
+            await gi.merge_pr("owner", "repo", 42)
+
+    @pytest.mark.anyio
+    async def test_merge_method_included_in_elicitation_prompt(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(return_value=_mock_response(json_data={"merged": True}))
+        ctx = _mock_ctx()
+        ctx.elicit.return_value = MagicMock(action="accept")
+        await gi.merge_pr("owner", "repo", 42, merge_method="rebase", ctx=ctx)
+        prompt = ctx.elicit.call_args[0][0]
+        assert "rebase" in prompt
+        assert "42" in prompt
+
+
+# ---------------------------------------------------------------------------
+# get_user_activities — Context progress ordering and completeness
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserActivitiesContext:
+    @pytest.mark.anyio
+    async def test_no_ctx_runs_without_error(self, gi: GitHubIntegration):
+        with patch.object(asyncio, "to_thread", new_callable=AsyncMock, return_value=_EMPTY_CONTRIBUTIONS):
+            result = await gi.get_user_activities("user1")
+        assert result["username"] == "user1"
+        assert result["commits"] == []
+
+    @pytest.mark.anyio
+    async def test_pre_call_info_fires_before_graphql(self, gi: GitHubIntegration):
+        """ctx.info('Querying...') must appear before the asyncio.to_thread call."""
+        order: list[str] = []
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            order.append("graphql")
+            return _EMPTY_CONTRIBUTIONS
+
+        ctx = _mock_ctx()
+        ctx.info.side_effect = lambda msg: order.append(f"info:{msg}")
+
+        with patch.object(asyncio, "to_thread", side_effect=fake_to_thread):
+            await gi.get_user_activities("user1", ctx=ctx)
+
+        assert order[0].startswith("info:Querying")
+        assert order[1] == "graphql"
+
+    @pytest.mark.anyio
+    async def test_progress_reported_five_times(self, gi: GitHubIntegration):
+        ctx = _mock_ctx()
+        with patch.object(asyncio, "to_thread", new_callable=AsyncMock, return_value=_EMPTY_CONTRIBUTIONS):
+            await gi.get_user_activities("user1", ctx=ctx)
+        assert ctx.report_progress.call_count == 5
+        progress_values = [c.kwargs["progress"] for c in ctx.report_progress.call_args_list]
+        assert progress_values == [0, 1, 2, 3, 4]
+
+    @pytest.mark.anyio
+    async def test_stage_info_messages_sent(self, gi: GitHubIntegration):
+        ctx = _mock_ctx()
+        with patch.object(asyncio, "to_thread", new_callable=AsyncMock, return_value=_EMPTY_CONTRIBUTIONS):
+            await gi.get_user_activities("user1", ctx=ctx)
+        info_calls = [c.args[0] for c in ctx.info.call_args_list]
+        # pre-call + 4 stage messages
+        assert len(info_calls) == 5
+        assert any("commits" in m.lower() for m in info_calls)
+        assert any("pull requests" in m.lower() for m in info_calls)
+        assert any("issues" in m.lower() for m in info_calls)
+        assert any("reviews" in m.lower() for m in info_calls)
+
+    @pytest.mark.anyio
+    async def test_progress_total_is_always_four(self, gi: GitHubIntegration):
+        ctx = _mock_ctx()
+        with patch.object(asyncio, "to_thread", new_callable=AsyncMock, return_value=_EMPTY_CONTRIBUTIONS):
+            await gi.get_user_activities("user1", ctx=ctx)
+        totals = {c.kwargs["total"] for c in ctx.report_progress.call_args_list}
+        assert totals == {4}
+
+
+# ---------------------------------------------------------------------------
+# get_pr_status_checks — check_suites allocation is conditional on ctx
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrStatusChecks:
+    @pytest.mark.anyio
+    async def test_no_ctx_returns_result_without_info_call(self, gi: GitHubIntegration):
+        with patch.object(asyncio, "to_thread", new_callable=AsyncMock, return_value=_EMPTY_STATUS_CHECKS):
+            result = await gi.get_pr_status_checks("owner", "repo", 1, ctx=None)
+        assert "overall" in result
+        assert "check_runs" in result
+
+    @pytest.mark.anyio
+    async def test_ctx_info_includes_suite_run_and_status_counts(self, gi: GitHubIntegration):
+        ctx = _mock_ctx()
+        with patch.object(asyncio, "to_thread", new_callable=AsyncMock, return_value=_EMPTY_STATUS_CHECKS):
+            await gi.get_pr_status_checks("owner", "repo", 1, ctx=ctx)
+        ctx.info.assert_called_once()
+        msg = ctx.info.call_args[0][0]
+        assert "check suites" in msg
+        assert "runs" in msg
+        assert "statuses" in msg
+
+    @pytest.mark.anyio
+    async def test_check_suites_not_evaluated_without_ctx(self, gi: GitHubIntegration):
+        """Verify check_suites traversal only happens when ctx is provided."""
+        data = {
+            "repository": {
+                "pullRequest": {
+                    "headRef": {
+                        "target": {
+                            "checkSuites": {"nodes": [{"checkRuns": {"nodes": []}}] * 5},
+                            "status": None,
+                        }
+                    }
+                }
+            }
+        }
+        ctx = _mock_ctx()
+        with patch.object(asyncio, "to_thread", new_callable=AsyncMock, return_value=data):
+            await gi.get_pr_status_checks("owner", "repo", 1, ctx=ctx)
+        msg = ctx.info.call_args[0][0]
+        assert "5 check suites" in msg
+
+    @pytest.mark.anyio
+    async def test_overall_status_derived_correctly(self, gi: GitHubIntegration):
+        with patch.object(asyncio, "to_thread", new_callable=AsyncMock, return_value=_EMPTY_STATUS_CHECKS):
+            result = await gi.get_pr_status_checks("owner", "repo", 1)
+        assert result["overall"] == "unknown"


### PR DESCRIPTION
## What

All 20 MCP tools are now async-native. The four GraphQL tools participate in the [MCP background task protocol (SEP-1686)](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks), letting clients receive a task ID immediately and poll for the result rather than blocking.

## Why

- **REST tools**: were running on FastMCP's thread pool. Switching to `httpx.AsyncClient` removes the thread-pool dispatch and runs them directly in the event loop.
- **GraphQL tools**: hit the GitHub GraphQL API, which can be slow under rate-limiting or with large datasets. `task=True` means supporting clients stay responsive -- they get a task ID back immediately and retrieve the result when ready. Non-task clients are unaffected (`mode="optional"`).

## Changes

### Commit 1 - `_annotate`/decorator machinery + `search_user` + `get_user_activities`

- Reworked `_annotate`/`deco` to support two call shapes:
  - `@_read_only` - direct decoration, unchanged behaviour for all other tools
  - `@_read_only(task=True)` - returns a decorator, stamps `_mcp_task=True` on the method
- `register_tools()` reads `_mcp_task` and forwards it as `task=` to `mcp.tool()`
- `search_user` and `get_user_activities` - converted to `async def`, GraphQL calls wrapped in `asyncio.to_thread()` (FastMCP rejects `task=True` on sync functions at registration)

### Commit 2 - full async conversion

**REST tools** (`_request` switched to `httpx.AsyncClient`):
`get_pr_diff`, `get_pr_content`, `add_pr_comments`, `add_inline_pr_comment`, `update_pr_description`, `create_pr`, `list_open_issues_prs`, `create_issue`, `merge_pr`, `update_pr_branch`, `update_issue`, `update_reviews`, `update_assignees`, `get_latest_sha`, `create_tag`, `create_release`

**GraphQL tools** (`asyncio.to_thread` + `task=True`):
`get_pr_linked_issues`, `get_pr_status_checks`

## Result

| Count | Type | Transport |
|---|---|---|
| 16 | `async def` | REST via `httpx.AsyncClient` |
| 4 | `async def` + `task=True` | GraphQL via `asyncio.to_thread` |

## Compatibility

- All sync callers (non-task clients) work as before - `task=True` maps to `mode="optional"`
- Private helpers (`_get_headers`, `_resolve_token`, `_flatten_check_runs`, etc.) remain sync - no I/O
- `issues_pr_analyser.py` required only a one-line change in `register_tools()` to forward `_mcp_task`