### PR TITLE
fix(tools): stop registering aclose as an MCP tool

### DIFF
--- a/src/mcp_github/issues_pr_analyser.py
+++ b/src/mcp_github/issues_pr_analyser.py
@@ -115,8 +115,6 @@ class PRIssueAnalyser:
                 if annotations is not None:
                     task = getattr(method, "_mcp_task", False)
                     self.mcp.tool(annotations=annotations, task=task)(method)
-                else:
-                    self.mcp.add_tool(method)
         self.mcp.add_provider(SkillsDirectoryProvider(Path(__file__).parent / "skills"))
 
     def run(self) -> None:


### PR DESCRIPTION
## What

`register_tools()` had a fallback path that called `mcp.add_tool()` on any public routine without a `_mcp_annotations` attribute. `aclose` - the method that closes the shared `httpx.AsyncClient` - is public (no underscore prefix) and has no decorator, so it was being exposed as a callable MCP tool alongside the 20 intentional ones.

## Why it was wrong

`aclose` is an async lifecycle method, not an API operation. Exposing it lets any MCP client close the HTTP client mid-session, which would break all subsequent requests.

## Fix

Drop the `else` branch. All 20 intentional tools already carry `@_read_only`, `@_write`, or `@_destructive` - none relied on the fallback. Only annotated methods are now registered.

```diff
-                else:
-                    self.mcp.add_tool(method)
```

## Verification

Started the server in stdio mode and sent a `tools/list` request - 23 tools returned (20 business tools + 3 from FastMCP providers), `aclose` absent. 42 tests pass.