### PR TITLE
fix(tools): drop merge_pr elicitation, surface GitHub error message

### DIFF
--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -227,8 +227,12 @@ class GitHubIntegration:
             raise GitHubValidationError("Validation failed. Check your input data.", response_body=response_body)
 
         message = f"GitHub API error ({context})" if context else "GitHub API error"
+        gh_message = response_body.get("message") if isinstance(response_body, dict) else None
+        detail = f"{status} - {response.reason_phrase}"
+        if gh_message:
+            detail = f"{detail} - {gh_message}"
         raise GitHubAPIError(
-            f"{message}: {status} - {response.reason_phrase}",
+            f"{message}: {detail}",
             status_code=status,
             response_body=response_body,
         )
@@ -435,16 +439,8 @@ class GitHubIntegration:
         commit_title: str | None = None,
         commit_message: str | None = None,
         merge_method: Literal["merge", "squash", "rebase"] = "squash",
-        ctx: Context | None = None,
     ) -> dict[str, Any]:
         """Merges a specific pull request."""
-        if ctx:
-            confirmation = await ctx.elicit(
-                f"About to merge PR #{pr_number} in {repo_owner}/{repo_name} via '{merge_method}'. Confirm?",
-                response_type=None,
-            )
-            if confirmation.action != "accept":
-                raise GitHubValidationError("Merge cancelled.")
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/merge"
         payload: dict[str, Any] = {"merge_method": merge_method}
         if commit_title is not None:

--- a/src/mcp_github/skills/pr-management/SKILL.md
+++ b/src/mcp_github/skills/pr-management/SKILL.md
@@ -26,9 +26,9 @@ Create new pull requests, keep them up to date, and safely merge them when ready
 
 ### Merging a PR
 
-1. Confirm the PR is approved and all checks pass (check `mergeable` via `get_pr_content`)
+1. Confirm the PR is approved and all checks pass (check status via `get_pr_status_checks` and `get_pr_content`)
 2. Call `merge_pr` with the appropriate merge method
-3. **Always confirm with the user before merging**
+3. **Always confirm with the user in chat before calling `merge_pr` — the tool does not prompt**
 
 ## Tool Parameters
 

--- a/tests/test_github_integration.py
+++ b/tests/test_github_integration.py
@@ -9,7 +9,6 @@ import httpx
 import pytest
 from fastmcp.exceptions import ToolError
 
-from mcp_github.exceptions import GitHubValidationError
 from mcp_github.github_integration import (
     GitHubIntegration,
     _destructive,
@@ -199,7 +198,7 @@ class TestLifecycle:
 
 
 # ---------------------------------------------------------------------------
-# merge_pr — elicitation and dead-except removal
+# merge_pr — request shape and GitHub error surfacing
 # ---------------------------------------------------------------------------
 
 
@@ -211,48 +210,64 @@ class TestMergePr:
         assert result == {"merged": True}
 
     @pytest.mark.anyio
-    async def test_elicitation_accepted_proceeds_with_merge(self, gi: GitHubIntegration):
-        gi._http.request = AsyncMock(return_value=_mock_response(json_data={"merged": True}))
-        ctx = _mock_ctx()
-        ctx.elicit.return_value = MagicMock(action="accept")
-        result = await gi.merge_pr("owner", "repo", 42, ctx=ctx)
-        ctx.elicit.assert_called_once()
-        assert "squash" in ctx.elicit.call_args[0][0]
-        assert result == {"merged": True}
-
-    @pytest.mark.anyio
-    async def test_elicitation_declined_raises_validation_error(self, gi: GitHubIntegration):
-        ctx = _mock_ctx()
-        ctx.elicit.return_value = MagicMock(action="decline")
-        with pytest.raises(GitHubValidationError, match="Merge cancelled"):
-            await gi.merge_pr("owner", "repo", 42, ctx=ctx)
-        gi._http.request.assert_not_called()
-
-    @pytest.mark.anyio
-    async def test_elicitation_cancel_raises_validation_error(self, gi: GitHubIntegration):
-        ctx = _mock_ctx()
-        ctx.elicit.return_value = MagicMock(action="cancel")
-        with pytest.raises(GitHubValidationError):
-            await gi.merge_pr("owner", "repo", 42, ctx=ctx)
-        gi._http.request.assert_not_called()
-
-    @pytest.mark.anyio
-    async def test_http_error_propagates_as_tool_error(self, gi: GitHubIntegration):
+    async def test_http_error_propagates_as_tool_error_with_github_message(self, gi: GitHubIntegration):
         gi._http.request = AsyncMock(
             return_value=_mock_response(status_code=405, json_data={"message": "Not mergeable"})
         )
-        with pytest.raises(ToolError):
+        with pytest.raises(ToolError) as excinfo:
             await gi.merge_pr("owner", "repo", 42)
+        assert "Not mergeable" in str(excinfo.value)
+        assert "405" in str(excinfo.value)
 
     @pytest.mark.anyio
-    async def test_merge_method_included_in_elicitation_prompt(self, gi: GitHubIntegration):
+    async def test_merge_405_includes_github_message(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(
+            return_value=_mock_response(
+                status_code=405, json_data={"message": "Pull Request is not mergeable"}
+            )
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await gi.merge_pr("owner", "repo", 251)
+        text = str(excinfo.value)
+        assert "Pull Request is not mergeable" in text
+        assert "405" in text
+
+    @pytest.mark.anyio
+    async def test_merge_409_includes_github_message(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(
+            return_value=_mock_response(
+                status_code=409, json_data={"message": "Head branch was modified"}
+            )
+        )
+        with pytest.raises(ToolError) as excinfo:
+            await gi.merge_pr("owner", "repo", 42)
+        text = str(excinfo.value)
+        assert "Head branch was modified" in text
+        assert "409" in text
+
+    @pytest.mark.anyio
+    async def test_merge_does_not_accept_ctx_kwarg(self, gi: GitHubIntegration):
+        with pytest.raises(TypeError):
+            await gi.merge_pr("owner", "repo", 42, ctx=object())  # type: ignore[call-arg]
+
+    @pytest.mark.anyio
+    async def test_merge_payload_includes_optional_commit_fields(self, gi: GitHubIntegration):
         gi._http.request = AsyncMock(return_value=_mock_response(json_data={"merged": True}))
-        ctx = _mock_ctx()
-        ctx.elicit.return_value = MagicMock(action="accept")
-        await gi.merge_pr("owner", "repo", 42, merge_method="rebase", ctx=ctx)
-        prompt = ctx.elicit.call_args[0][0]
-        assert "rebase" in prompt
-        assert "42" in prompt
+        await gi.merge_pr(
+            "owner",
+            "repo",
+            42,
+            commit_title="Custom title",
+            commit_message="Custom message",
+            merge_method="rebase",
+        )
+        kwargs = gi._http.request.call_args.kwargs
+        payload = kwargs["json"]
+        assert payload == {
+            "merge_method": "rebase",
+            "commit_title": "Custom title",
+            "commit_message": "Custom message",
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two small changes to `merge_pr` and the surrounding error path.

### 1. Drop the in-tool elicitation

`merge_pr` used to take a `ctx` parameter and call `ctx.elicit(...)` to confirm before firing the merge. Two problems:

- Elicitation is optional in the MCP spec - clients that don't implement it (claude.ai web, some IDE integrations) couldn't merge at all, because the tool would either error or silently no-op depending on how the client handled the elicit request.
- For clients that do support it, the prompt was redundant. The calling LLM should already be confirming with the user in chat before invoking a destructive operation; bouncing through a second tool-level prompt added friction without adding safety.

The `ctx` parameter is removed. `skills/pr-management/SKILL.md` is updated to make the human-confirmation step explicit: confirm in chat, then call the tool.

### 2. Surface GitHub's error message on failed requests

`_handle_response_error` now appends the `message` field from GitHub's response body to `GitHubAPIError`. Before:

```
GitHub API error (PR #251 merge): 405 - Method Not Allowed
```

After:

```
GitHub API error (PR #251 merge): 405 - Method Not Allowed - Pull Request is not mergeable
```

This matters most for `merge_pr`, where the same 405/409 status can mean half a dozen different things (branch protection, dirty mergeable_state, base behind, required reviews missing, ...). The caller now sees which one without having to re-fetch the PR.

## Testing

```
uv run pytest        # 46 passed
uv run pyright src/mcp_github/github_integration.py  # 0 errors
```

Test changes: removed the three elicitation tests (`accepted_proceeds`, `declined_raises`, `cancel_raises`, `merge_method_in_prompt`). Added five covering the new shape:

- `test_http_error_propagates_as_tool_error_with_github_message`
- `test_merge_405_includes_github_message`
- `test_merge_409_includes_github_message`
- `test_merge_does_not_accept_ctx_kwarg` (regression guard)
- `test_merge_payload_includes_optional_commit_fields`

## Notes for reviewers

- `Context` is still imported and used by `search_user`, `get_user_activities`, and `get_pr_status_checks` - only `merge_pr` loses it.
- No change to the `@_write` annotation; merge is still a write, not destructive.
- The error-message append is gated on `isinstance(response_body, dict)`, so non-JSON 5xx responses fall back to the original "status - reason" format.