### PR TITLE
fix(tools): get_latest_sha empty-repo contract + paginate get_pr_status_checks

### DIFF
--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -537,7 +537,7 @@ class GitHubIntegration:
         data = (await self._request("GET", url, context=f"commits for {repo_owner}/{repo_name}")).json()
         if data:
             return data[0]["sha"]
-        return "No commits found in the repository"
+        return None
 
     @_write
     async def create_tag(self, repo_owner: str, repo_name: str, tag_name: str, message: str) -> dict[str, Any]:
@@ -545,7 +545,7 @@ class GitHubIntegration:
         url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs"
         latest_sha = await self.get_latest_sha(repo_owner, repo_name)
         if not latest_sha:
-            raise ValueError("Failed to fetch the latest commit SHA")
+            raise GitHubNotFoundError(f"No commits found in {repo_owner}/{repo_name}; cannot create tag {tag_name}")
         return (
             await self._request(
                 "POST",

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -46,7 +46,13 @@ from .exceptions import (
     GitHubValidationError,
 )
 from .graphql_client import GraphQLClient
-from .graphql_queries import PR_LINKED_ISSUES_QUERY, PR_STATUS_CHECKS_QUERY, SEARCH_USER_QUERY, USER_CONTRIBUTIONS_QUERY
+from .graphql_queries import (
+    CHECK_SUITE_RUNS_QUERY,
+    PR_LINKED_ISSUES_QUERY,
+    PR_STATUS_CHECKS_QUERY,
+    SEARCH_USER_QUERY,
+    USER_CONTRIBUTIONS_QUERY,
+)
 
 
 class PRContent(TypedDict):
@@ -123,10 +129,13 @@ class StatusChecksResult(TypedDict):
     overall: str
     check_runs: list[dict[str, Any]]
     commit_statuses: list[dict[str, Any]]
+    truncated: bool
 
 
 GITHUB_TOKEN = getenv("GITHUB_TOKEN")
 TIMEOUT = int(getenv("GITHUB_API_TIMEOUT", "5"))  # seconds, configurable via env
+MAX_STATUS_CHECKS_SUITE_PAGES = 5  # 50 suites per page × 5 = 250 suite ceiling
+MAX_STATUS_CHECKS_RUN_PAGES_PER_SUITE = 5  # 100 runs per page × 5 = 500 run ceiling per suite
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARNING)
@@ -984,8 +993,19 @@ class GitHubIntegration:
         in_progress = {r["status"] for r in check_runs if r["status"] != "COMPLETED"}
         return bool(in_progress & pending) or "PENDING" in legacy
 
-    def _derive_overall(self, check_runs: list[dict[str, Any]], commit_statuses: list[dict[str, Any]]) -> str:
-        """Derive a single overall status string from check runs and commit statuses."""
+    def _derive_overall(
+        self,
+        check_runs: list[dict[str, Any]],
+        commit_statuses: list[dict[str, Any]],
+        truncated: bool = False,
+    ) -> str:
+        """Derive a single overall status string from check runs and commit statuses.
+
+        When truncated is True and no failure or pending signal is observed,
+        return 'unknown' rather than 'passing' — the missed pages could
+        contain a failing run. Failure and pending signals stay authoritative.
+
+        """
         if not check_runs and not commit_statuses:
             return "unknown"
         legacy = {ctx["state"] for ctx in commit_statuses}
@@ -993,9 +1013,47 @@ class GitHubIntegration:
             return "failing"
         if self._has_pending_checks(check_runs, legacy):
             return "pending"
+        if truncated:
+            return "unknown"
         return "passing"
 
     @_read_only(task=True)
+    async def _drain_suite_runs(
+        self, suite_id: str, app_name: str, after: str | None, token: str
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Page through remaining check runs for a single suite via CHECK_SUITE_RUNS_QUERY.
+
+        Returns the accumulated run dicts and whether the per-suite page cap
+        was hit before exhausting the connection.
+
+        """
+        runs: list[dict[str, Any]] = []
+        cursor = after
+        for _ in range(MAX_STATUS_CHECKS_RUN_PAGES_PER_SUITE):
+            result = await asyncio.to_thread(
+                self.graphql.execute_query,
+                CHECK_SUITE_RUNS_QUERY,
+                variables={"suiteId": suite_id, "after": cursor},
+                token=token,
+            )
+            node = result.get("node") or {}
+            run_conn = node.get("checkRuns") or {}
+            for run in run_conn.get("nodes") or []:
+                runs.append(
+                    {
+                        "name": run["name"],
+                        "status": run["status"],
+                        "conclusion": run.get("conclusion"),
+                        "details_url": run.get("detailsUrl"),
+                        "suite_app": app_name,
+                    }
+                )
+            page_info = run_conn.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                return runs, False
+            cursor = page_info.get("endCursor")
+        return runs, True
+
     async def get_pr_status_checks(
         self,
         repo_owner: str,
@@ -1003,34 +1061,89 @@ class GitHubIntegration:
         pr_number: int,
         ctx: Context | None = None,
     ) -> StatusChecksResult:
-        """Return the CI check runs and commit status for a pull request's HEAD commit."""
+        """Return the CI check runs and commit status for a pull request's HEAD commit.
+
+        Pages through up to MAX_STATUS_CHECKS_SUITE_PAGES of check suites
+        (50 per page). For any suite whose first 100 runs are not the full
+        set, drains up to MAX_STATUS_CHECKS_RUN_PAGES_PER_SUITE additional
+        pages via the supplemental query. If either cap is hit before the
+        connection is exhausted, the result is flagged truncated=True and
+        overall is downgraded from 'passing' to 'unknown' so the caller
+        does not act on a partial view.
+
+        """
         logger.info(f"Fetching status checks for PR #{pr_number} in {repo_owner}/{repo_name}")
         try:
-            result = await asyncio.to_thread(
-                self.graphql.execute_query,
-                PR_STATUS_CHECKS_QUERY,
-                variables={"owner": repo_owner, "repo": repo_name, "number": pr_number},
-                token=self._resolve_token(),
-            )
-            repo_data = result.get("repository")
-            if not repo_data or not repo_data.get("pullRequest"):
-                raise GitHubNotFoundError(f"PR #{pr_number} not found in {repo_owner}/{repo_name}")
-            head_target = (repo_data["pullRequest"].get("headRef") or {}).get("target") or {}
-            check_runs = self._flatten_check_runs(head_target)
-            commit_statuses = self._extract_commit_statuses(head_target)
+            check_runs: list[dict[str, Any]] = []
+            commit_statuses: list[dict[str, Any]] = []
+            n_suites = 0
+            truncated = False
+            suites_after: str | None = None
+            token = self._resolve_token()
+
+            for _ in range(MAX_STATUS_CHECKS_SUITE_PAGES):
+                result = await asyncio.to_thread(
+                    self.graphql.execute_query,
+                    PR_STATUS_CHECKS_QUERY,
+                    variables={
+                        "owner": repo_owner,
+                        "repo": repo_name,
+                        "number": pr_number,
+                        "suitesAfter": suites_after,
+                    },
+                    token=token,
+                )
+                repo_data = result.get("repository")
+                if not repo_data or not repo_data.get("pullRequest"):
+                    raise GitHubNotFoundError(f"PR #{pr_number} not found in {repo_owner}/{repo_name}")
+                head_target = (repo_data["pullRequest"].get("headRef") or {}).get("target") or {}
+
+                if suites_after is None:
+                    commit_statuses = self._extract_commit_statuses(head_target)
+
+                suites_page = head_target.get("checkSuites") or {}
+                suites_nodes = suites_page.get("nodes") or []
+                n_suites += len(suites_nodes)
+                check_runs.extend(self._flatten_check_runs(head_target))
+
+                for suite in suites_nodes:
+                    runs_page = (suite.get("checkRuns") or {}).get("pageInfo") or {}
+                    if not runs_page.get("hasNextPage"):
+                        continue
+                    extra_runs, runs_capped = await self._drain_suite_runs(
+                        suite_id=suite["id"],
+                        app_name=(suite.get("app") or {}).get("name", "unknown"),
+                        after=runs_page.get("endCursor"),
+                        token=token,
+                    )
+                    check_runs.extend(extra_runs)
+                    if runs_capped:
+                        truncated = True
+
+                page_info = suites_page.get("pageInfo") or {}
+                if not page_info.get("hasNextPage"):
+                    break
+                suites_after = page_info.get("endCursor")
+            else:
+                truncated = True
+
             if ctx:
-                n_suites = len(head_target.get("checkSuites", {}).get("nodes", []))
+                trailer = " (truncated)" if truncated else ""
                 await ctx.info(
                     f"Found {n_suites} check suites, "
-                    f"{len(check_runs)} runs, {len(commit_statuses)} legacy statuses"
+                    f"{len(check_runs)} runs, {len(commit_statuses)} legacy statuses{trailer}"
                 )
-            overall = self._derive_overall(check_runs, commit_statuses)
-            logger.info(f"Status checks for PR #{pr_number}: overall={overall}, runs={len(check_runs)}")
+            overall = self._derive_overall(check_runs, commit_statuses, truncated=truncated)
+            logger.info(
+                f"Status checks for PR #{pr_number}: overall={overall}, "
+                f"runs={len(check_runs)}, truncated={truncated}"
+            )
             return {
                 "pr_number": pr_number,
                 "overall": overall,
                 "check_runs": check_runs,
                 "commit_statuses": commit_statuses,
+                "truncated": truncated,
             }
         except GitHubNotFoundError:
             raise

--- a/src/mcp_github/github_integration.py
+++ b/src/mcp_github/github_integration.py
@@ -1013,7 +1013,6 @@ class GitHubIntegration:
             return "unknown"
         return "passing"
 
-    @_read_only(task=True)
     async def _drain_suite_runs(
         self, suite_id: str, app_name: str, after: str | None, token: str
     ) -> tuple[list[dict[str, Any]], bool]:
@@ -1050,6 +1049,7 @@ class GitHubIntegration:
             cursor = page_info.get("endCursor")
         return runs, True
 
+    @_read_only(task=True)
     async def get_pr_status_checks(
         self,
         repo_owner: str,

--- a/src/mcp_github/graphql_queries.py
+++ b/src/mcp_github/graphql_queries.py
@@ -88,22 +88,35 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }
 """
 
-# Query to fetch check runs and commit status for a PR's HEAD commit
+# Query to fetch check runs and commit status for a PR's HEAD commit.
+# Paginates check suites via $suitesAfter. Runs-within-suite are returned
+# 100 at a time alongside an endCursor and hasNextPage; if a suite has
+# more, the caller follows up with CHECK_SUITE_RUNS_QUERY using the
+# suite's node id.
 PR_STATUS_CHECKS_QUERY = """
-query($owner: String!, $repo: String!, $number: Int!) {
+query($owner: String!, $repo: String!, $number: Int!, $suitesAfter: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
       headRef {
         target {
           ... on Commit {
-            checkSuites(first: 20) {
+            checkSuites(first: 50, after: $suitesAfter) {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
               nodes {
+                id
                 app {
                   name
                 }
                 status
                 conclusion
-                checkRuns(first: 20) {
+                checkRuns(first: 100) {
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
                   nodes {
                     name
                     status
@@ -123,6 +136,30 @@ query($owner: String!, $repo: String!, $number: Int!) {
               }
             }
           }
+        }
+      }
+    }
+  }
+}
+"""
+
+# Supplemental query: paginate check runs for a single check suite by id.
+# Used to drain the runs of a suite whose first page was truncated by
+# PR_STATUS_CHECKS_QUERY.
+CHECK_SUITE_RUNS_QUERY = """
+query($suiteId: ID!, $after: String) {
+  node(id: $suiteId) {
+    ... on CheckSuite {
+      checkRuns(first: 100, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          name
+          status
+          conclusion
+          detailsUrl
         }
       }
     }

--- a/tests/test_github_integration.py
+++ b/tests/test_github_integration.py
@@ -476,3 +476,161 @@ class TestGetLatestShaAndCreateTag:
         with pytest.raises(GitHubNotFoundError, match="No commits found"):
             await gi.create_tag("owner", "empty-repo", "v1.0.0", "First tag")
         gi._http.request.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# get_pr_status_checks — pagination + truncation
+# ---------------------------------------------------------------------------
+
+
+def _status_page(
+    suites: list[dict],
+    *,
+    has_next: bool = False,
+    end_cursor: str | None = None,
+    status: dict | None = None,
+) -> dict:
+    return {
+        "repository": {
+            "pullRequest": {
+                "headRef": {
+                    "target": {
+                        "checkSuites": {
+                            "pageInfo": {"hasNextPage": has_next, "endCursor": end_cursor},
+                            "nodes": suites,
+                        },
+                        "status": status,
+                    }
+                }
+            }
+        }
+    }
+
+
+def _suite(runs: list[dict], *, runs_has_next: bool = False, app: str = "GitHub Actions") -> dict:
+    return {
+        "app": {"name": app},
+        "status": "COMPLETED",
+        "conclusion": "SUCCESS",
+        "checkRuns": {
+            "pageInfo": {"hasNextPage": runs_has_next},
+            "nodes": runs,
+        },
+    }
+
+
+def _run(name: str, conclusion: str = "SUCCESS", status: str = "COMPLETED") -> dict:
+    return {"name": name, "status": status, "conclusion": conclusion, "detailsUrl": f"https://x/{name}"}
+
+
+def _suite_with_id(id_: str, runs: list[dict], *, runs_has_next: bool = False, app: str = "GitHub Actions") -> dict:
+    suite = _suite(runs, runs_has_next=runs_has_next, app=app)
+    suite["id"] = id_
+    suite["checkRuns"]["pageInfo"]["endCursor"] = "runs-cursor" if runs_has_next else None
+    return suite
+
+
+def _runs_page(runs: list[dict], *, has_next: bool = False) -> dict:
+    return {
+        "node": {
+            "checkRuns": {
+                "pageInfo": {"hasNextPage": has_next, "endCursor": "next" if has_next else None},
+                "nodes": runs,
+            }
+        }
+    }
+
+
+class TestStatusChecksPagination:
+    @pytest.mark.anyio
+    async def test_paginates_suites_until_complete(self, gi: GitHubIntegration):
+        page1 = _status_page([_suite_with_id("s1", [_run("a")])], has_next=True, end_cursor="cursor-1")
+        page2 = _status_page([_suite_with_id("s2", [_run("b")])], has_next=False)
+        with patch.object(asyncio, "to_thread", new_callable=AsyncMock, side_effect=[page1, page2]) as p:
+            result = await gi.get_pr_status_checks("owner", "repo", 1)
+        assert p.await_count == 2
+        assert {r["name"] for r in result["check_runs"]} == {"a", "b"}
+        assert result["truncated"] is False
+        assert result["overall"] == "passing"
+
+    @pytest.mark.anyio
+    async def test_truncated_when_suite_cap_hit(self, gi: GitHubIntegration):
+        infinite_page = _status_page([_suite_with_id("s1", [_run("x")])], has_next=True, end_cursor="more")
+        with patch.object(
+            asyncio, "to_thread", new_callable=AsyncMock, side_effect=[infinite_page] * 10
+        ) as p:
+            result = await gi.get_pr_status_checks("owner", "repo", 1)
+        assert p.await_count == 5
+        assert result["truncated"] is True
+
+    @pytest.mark.anyio
+    async def test_drains_extra_runs_within_suite(self, gi: GitHubIntegration):
+        suite_page = _status_page([_suite_with_id("s1", [_run("a")], runs_has_next=True)])
+        extra_runs = _runs_page([_run("b"), _run("c")], has_next=False)
+        with patch.object(
+            asyncio, "to_thread", new_callable=AsyncMock, side_effect=[suite_page, extra_runs]
+        ) as p:
+            result = await gi.get_pr_status_checks("owner", "repo", 1)
+        assert p.await_count == 2
+        assert {r["name"] for r in result["check_runs"]} == {"a", "b", "c"}
+        assert result["truncated"] is False
+        assert result["overall"] == "passing"
+
+    @pytest.mark.anyio
+    async def test_truncated_when_run_cap_hit_per_suite(self, gi: GitHubIntegration):
+        suite_page = _status_page([_suite_with_id("s1", [_run("a")], runs_has_next=True)])
+        infinite_runs = _runs_page([_run("more")], has_next=True)
+        with patch.object(
+            asyncio,
+            "to_thread",
+            new_callable=AsyncMock,
+            side_effect=[suite_page, *([infinite_runs] * 10)],
+        ) as p:
+            result = await gi.get_pr_status_checks("owner", "repo", 1)
+        # 1 suite query + 5 run-pagination queries (MAX_STATUS_CHECKS_RUN_PAGES_PER_SUITE)
+        assert p.await_count == 6
+        assert result["truncated"] is True
+        assert result["overall"] == "unknown"
+
+    @pytest.mark.anyio
+    async def test_truncated_keeps_failure_authoritative(self, gi: GitHubIntegration):
+        suite_page = _status_page(
+            [_suite_with_id("s1", [_run("failed", conclusion="FAILURE")], runs_has_next=True)]
+        )
+        infinite_runs = _runs_page([_run("more")], has_next=True)
+        with patch.object(
+            asyncio,
+            "to_thread",
+            new_callable=AsyncMock,
+            side_effect=[suite_page, *([infinite_runs] * 10)],
+        ):
+            result = await gi.get_pr_status_checks("owner", "repo", 1)
+        assert result["truncated"] is True
+        assert result["overall"] == "failing"
+
+    @pytest.mark.anyio
+    async def test_drained_runs_inherit_suite_app(self, gi: GitHubIntegration):
+        suite_page = _status_page(
+            [_suite_with_id("s1", [_run("a")], runs_has_next=True, app="Codacy Production")]
+        )
+        extra_runs = _runs_page([_run("b")], has_next=False)
+        with patch.object(
+            asyncio, "to_thread", new_callable=AsyncMock, side_effect=[suite_page, extra_runs]
+        ):
+            result = await gi.get_pr_status_checks("owner", "repo", 1)
+        assert all(r["suite_app"] == "Codacy Production" for r in result["check_runs"])
+
+    @pytest.mark.anyio
+    async def test_ctx_info_announces_truncation(self, gi: GitHubIntegration):
+        suite_page = _status_page([_suite_with_id("s1", [_run("a")], runs_has_next=True)])
+        infinite_runs = _runs_page([_run("x")], has_next=True)
+        ctx = _mock_ctx()
+        with patch.object(
+            asyncio,
+            "to_thread",
+            new_callable=AsyncMock,
+            side_effect=[suite_page, *([infinite_runs] * 10)],
+        ):
+            await gi.get_pr_status_checks("owner", "repo", 1, ctx=ctx)
+        msg = ctx.info.call_args[0][0]
+        assert "truncated" in msg

--- a/tests/test_github_integration.py
+++ b/tests/test_github_integration.py
@@ -9,7 +9,7 @@ import httpx
 import pytest
 from fastmcp.exceptions import ToolError
 
-from mcp_github.exceptions import GitHubValidationError
+from mcp_github.exceptions import GitHubNotFoundError, GitHubValidationError
 from mcp_github.github_integration import (
     GitHubIntegration,
     _destructive,
@@ -450,3 +450,29 @@ class TestGetPrStatusChecks:
         with patch.object(asyncio, "to_thread", new_callable=AsyncMock, return_value=_EMPTY_STATUS_CHECKS):
             result = await gi.get_pr_status_checks("owner", "repo", 1)
         assert result["overall"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# get_latest_sha + create_tag — empty-repo contract
+# ---------------------------------------------------------------------------
+
+
+class TestGetLatestShaAndCreateTag:
+    @pytest.mark.anyio
+    async def test_get_latest_sha_empty_repo_returns_none(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(return_value=_mock_response(json_data=[]))
+        result = await gi.get_latest_sha("owner", "empty-repo")
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_get_latest_sha_returns_sha_when_commits_exist(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(return_value=_mock_response(json_data=[{"sha": "abc123"}]))
+        result = await gi.get_latest_sha("owner", "repo")
+        assert result == "abc123"
+
+    @pytest.mark.anyio
+    async def test_create_tag_empty_repo_raises_github_not_found(self, gi: GitHubIntegration):
+        gi._http.request = AsyncMock(return_value=_mock_response(json_data=[]))
+        with pytest.raises(GitHubNotFoundError, match="No commits found"):
+            await gi.create_tag("owner", "empty-repo", "v1.0.0", "First tag")
+        gi._http.request.assert_awaited_once()


### PR DESCRIPTION
## What

Two related reliability fixes to tools the LLM uses to make decisions. Bundled because they're both small but landing them together avoids two separate review cycles for changes in the same area of `github_integration.py`.

### 1. `get_latest_sha` empty-repo contract

`get_latest_sha` was annotated `-> str | None` but returned the truthy literal `"No commits found in the repository"` when the commits list was empty. `create_tag`'s guard (`if not latest_sha`) did not fire, the string was sent to GitHub as the tag SHA, and the response was a 422 that gave callers no hint the repo was simply empty.

- `get_latest_sha` now returns `None` on empty repos.
- `create_tag` raises `GitHubNotFoundError` with a message naming the repo, so callers get a precise error type they can branch on.

Tests cover the empty-list, non-empty-list, and create_tag-on-empty-repo paths.

### 2. Paginate `get_pr_status_checks`, flag truncation

`PR_STATUS_CHECKS_QUERY` capped `checkSuites(first: 20)` and `checkRuns(first: 20)` per suite. Anything past the first page was silently dropped, and `_derive_overall` could return `"passing"` when the failing run was simply on page two. Bad failure mode for a signal the LLM uses to gate merges.

**Pagination:**
- Suites: `MAX_STATUS_CHECKS_SUITE_PAGES = 5` × 50 per page = 250 suite ceiling.
- Runs within a suite: `MAX_STATUS_CHECKS_RUN_PAGES_PER_SUITE = 5` × 100 per page = 500 run ceiling per suite. The new `CHECK_SUITE_RUNS_QUERY` drains additional pages by suite node id when the first page is partial.

**Truncation surfacing:**
- `StatusChecksResult` gains `truncated: bool`, set when either ceiling is hit.
- `_derive_overall` takes a `truncated` kwarg. When set and no failure or pending signal is observed, returns `"unknown"` instead of `"passing"`. This is the conservative rule: a failing run could exist on the page we didn't fetch, so we refuse to claim green. **Failure and pending signals stay authoritative — truncation cannot undo a failure already observed.**
- `ctx.info()` reports the truncated state alongside the suite/run counts.

## Why the run-pagination is in this PR

The simpler design would be to cap runs at 100 per suite and flag truncation. That correctly avoids false greenlights but downgrades a 144-run matrix build with all green to `"unknown"` — annoying but safe. Draining runs by suite node id keeps "passing" accurate for realistic large matrices (up to 500 runs/suite) at the cost of one extra GraphQL query per truncated suite. That's a worthwhile trade for a signal the LLM uses to merge.

## Testing

```
uv run pytest                                            # 41 passed (was 34)
uv run pyright src/mcp_github/                           # 0 errors
```

New tests:

- `test_get_latest_sha_empty_repo_returns_none`
- `test_get_latest_sha_returns_sha_when_commits_exist`
- `test_create_tag_empty_repo_raises_github_not_found`
- `test_paginates_suites_until_complete`
- `test_truncated_when_suite_cap_hit`
- `test_drains_extra_runs_within_suite`
- `test_truncated_when_run_cap_hit_per_suite`
- `test_truncated_keeps_failure_authoritative` (regression guard for the no-false-greenlight rule)
- `test_drained_runs_inherit_suite_app`
- `test_ctx_info_announces_truncation`

## Notes for reviewers

- No backwards-incompatible change to `StatusChecksResult`; the new `truncated` field is additive.
- `_derive_overall` keeps the same public behaviour when called without `truncated` (the default is `False`).
- The ceilings (`5 × 50` suites, `5 × 100` runs/suite) are constants at module top; bump if a real repo hits them.
- This branch was cut from main before PR #262 merges, so no conflicts with `merge_pr`. The two PRs are orthogonal.

## Out of scope (logged for follow-up)

- `get_pr_comments` / `list_pr_review_comments` tools — the LLM can post review comments but can't read them.
- Redis password URL-decoding in `auth.py:76`.
- `USER_CONTRIBUTIONS_QUERY` per-repo contribution truncation.