### PR TITLE
docs(skills): state the title convention for issues, PRs and commits

### DIFF
--- a/src/mcp_github/skills/issue-management/SKILL.md
+++ b/src/mcp_github/skills/issue-management/SKILL.md
@@ -62,6 +62,34 @@ Create new issues, update existing ones, and list open issues or PRs with filter
 | `per_page` | int | `50` | Results per page (max 100) |
 | `page` | int | `1` | Page number |
 
+## Title Convention
+
+Every issue title uses the same shape as PR titles and commit subjects:
+
+```
+<type>(<scope>): <short prose summary>
+```
+
+| Part | Rules |
+|---|---|
+| `<type>` | One of `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `ci`, `build` |
+| `<scope>` | Lowercase area the change touches -- `auth`, `tools`, `deps`, `cache`, `skills`, `readme`, `k8s`. Use `/` for a compound scope (`docker/k8s`) |
+| Summary | Prose, not a slug. Lowercase start, imperative mood, no trailing full stop, roughly 72 characters or fewer |
+
+Examples:
+
+- `fix(cache): redis client leaks connections after reconnect`
+- `feat(auth): support GitHub App installation tokens`
+- `chore(deps): bump fastmcp-slim to 3.4.7`
+- `docs(readme): document the skill:// resource URIs`
+
+Avoid:
+
+- Bare titles -- `Update README`
+- Bracketed prefixes -- `[BUG] cache broken`
+- A kebab-case slug where prose belongs -- `fix(cache): redis-connection-leak`
+- A type with no scope -- `fix: cache broken`
+
 ## Filtering Guide
 
 | Filter | Returns issues/PRs where you are... |
@@ -74,6 +102,8 @@ Create new issues, update existing ones, and list open issues or PRs with filter
 ## Best Practices
 
 - Always search for duplicates with `list_open_issues_prs` before creating a new issue
+- Title every issue as `<type>(<scope>): <prose summary>` -- see Title Convention above
+- Keep the type honest: `fix` for defects, `feat` for new behaviour, `chore` for maintenance
 - Write issue bodies in Markdown; include steps to reproduce for bugs, or acceptance criteria for features
 - Use labels consistently — common labels: `bug`, `enhancement`, `documentation`, `good first issue`
 - Close issues with `state="closed"` once resolved rather than deleting them

--- a/src/mcp_github/skills/pr-management/SKILL.md
+++ b/src/mcp_github/skills/pr-management/SKILL.md
@@ -74,6 +74,38 @@ Create new pull requests, keep them up to date, and safely merge them when ready
 | `commit_message` | str | optional | Custom merge commit message |
 | `merge_method` | str | `squash` | One of: `merge`, `squash`, `rebase` |
 
+## Title Convention
+
+PR titles and commit subjects share one shape with issue titles:
+
+```
+<type>(<scope>): <short prose summary>
+```
+
+| Part | Rules |
+|---|---|
+| `<type>` | One of `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `ci`, `build` |
+| `<scope>` | Lowercase area the change touches -- `auth`, `tools`, `deps`, `cache`, `skills`, `readme`, `k8s`. Use `/` for a compound scope (`docker/k8s`) |
+| Summary | Prose, not a slug. Lowercase start, imperative mood, no trailing full stop, roughly 72 characters or fewer |
+
+This applies to `title` in `create_pr`, `new_title` in `update_pr_description`, and
+`commit_title` in `merge_pr`. When squashing, set `commit_title` explicitly so the
+subject landing on the default branch keeps this form rather than inheriting a
+branch commit -- append the PR reference, e.g. `feat(auth): support GitHub App tokens (#123)`.
+
+Examples:
+
+- `fix(tools): handle empty diff response from the compare endpoint`
+- `feat(cache): add Redis-backed PR diff cache`
+- `chore(deps): bump fastmcp-slim to 3.4.7, refresh lock`
+
+Avoid:
+
+- Bare titles -- `Update README`
+- Bracketed prefixes -- `[WIP] cache work`
+- A kebab-case slug where prose belongs -- `fix(tools): empty-diff-handling`
+- A type with no scope -- `fix: empty diff`
+
 ## Merge Method Guide
 
 | Method | When to use |
@@ -84,6 +116,8 @@ Create new pull requests, keep them up to date, and safely merge them when ready
 
 ## Best Practices
 
+- Title every PR as `<type>(<scope>): <prose summary>` -- see Title Convention above
+- Pass an explicit `commit_title` in the same form when merging, so the branch history stays parseable
 - Write PR bodies in Markdown; include a summary, motivation, and testing steps
 - Always verify `mergeable` status before calling `merge_pr`
 - Use `draft=True` for work-in-progress PRs to prevent premature merges

--- a/src/mcp_github/skills/release-management/SKILL.md
+++ b/src/mcp_github/skills/release-management/SKILL.md
@@ -97,7 +97,10 @@ Rules:
 - Use `--` (double dash), never em-dashes
 - Date is `YYYY-MM-DD` from the current date
 - Omit `Breaking Changes` and `New Environment Variables` sections when not applicable
-- `What Changed` lists every commit in the release using conventional commit format
+- `What Changed` lists every commit in the release as `<type>(<scope>): <prose summary>` -- the same
+  form used for issue and PR titles. `<type>` is one of `feat`, `fix`, `chore`, `docs`, `refactor`,
+  `test`, `perf`, `ci`, `build`; `<scope>` is the lowercase area touched (`auth`, `deps`, `cache`);
+  the summary is prose, not a kebab-case slug
 - Short SHA is the first 7 characters of the commit hash
 - `Full Changelog` URL compares the previous tag to the new tag
 


### PR DESCRIPTION
Fixes #289.

`issue-management` and `pr-management` now each carry a Title Convention section giving the shape as a type, a scope in parentheses, and a short prose summary. Each states the accepted types, defines the scope as the lowercase area the change touches, sets the summary as prose in the imperative with no trailing full stop, and follows with worked examples plus the forms to avoid - bare titles, bracketed prefixes, a kebab-case slug where prose belongs, and a type with no scope.

The `pr-management` copy names the three parameters it governs: `title` on `create_pr`, `new_title` on `update_pr_description`, and `commit_title` on `merge_pr`. `commit_title` gets its own paragraph because it is the one that silently escapes the convention. `merge_pr` defaults to a squash merge and treats `commit_title` as optional, so leaving it unset means the subject landing on the default branch is inherited from whichever commit the branch ended on. The skill now says to set it explicitly, in the same shape, with the PR reference appended.

`release-management` asked for "conventional commit format" in its `What Changed` rules without ever defining it. That line now spells out the same shape as the other two skills, so the release notes and the titles feeding them describe one convention rather than three.

The type list and the scope examples are drawn from this repository's own commit history rather than invented, so an agent following the convention produces titles consistent with what is already on `main`. The convention is written out in full in both skills instead of one cross-referencing the other, because skills are served individually over `skill://` and a reader may load only one of them.

The change is confined to Markdown under `src/mcp_github/skills/`. The test suite passes at 65 tests and `ruff check src/` is clean, though neither exercises skill content - there is no test asserting anything about what a SKILL.md says, so those results confirm the change broke nothing rather than that the new text is correct. The YAML frontmatter of all six skills was checked separately and is unchanged, so the files still load through `SkillsDirectoryProvider`.